### PR TITLE
Update AbstractQueueProvider.cfc

### DIFF
--- a/models/Jobs/AbstractJob.cfc
+++ b/models/Jobs/AbstractJob.cfc
@@ -81,8 +81,8 @@ component accessors="true" {
 	public struct function getMemento() {
 		return {
 			"id" : this.getId(),
-			"connection": this.getConnection(),
-			"queue": this.getQueue(),
+			"connection" : this.getConnection(),
+			"queue" : this.getQueue(),
 			"mapping" : this.getMapping(),
 			"properties" : this.getProperties(),
 			"backoff" : this.getBackoff(),

--- a/models/Jobs/BatchableJob.cfc
+++ b/models/Jobs/BatchableJob.cfc
@@ -21,8 +21,8 @@ component extends="AbstractJob" accessors="true" {
 	public struct function getMemento() {
 		return {
 			"id" : this.getId(),
-			"connection": this.getConnection(),
-			"queue": this.getQueue(),
+			"connection" : this.getConnection(),
+			"queue" : this.getQueue(),
 			"mapping" : this.getMapping(),
 			"properties" : this.getProperties(),
 			"backoff" : this.getBackoff(),

--- a/models/Providers/AbstractQueueProvider.cfc
+++ b/models/Providers/AbstractQueueProvider.cfc
@@ -44,7 +44,7 @@ component accessors="true" {
 		param config.properties = {};
 
 		instance.setId( arguments.jobId );
-		instance.setQueue( isNull( config.backoff ) ? javacast( "null", "" ) : config.backoff );
+		instance.setQueue( isNull( config.queue ) ? javacast( "null", "" ) : config.queue );
 		instance.setConnection( isNull( config.connection ) ? javacast( "null", "" ) : config.connection );
 		instance.setBackoff( isNull( config.backoff ) ? javacast( "null", "" ) : config.backoff );
 		instance.setTimeout( isNull( config.timeout ) ? javacast( "null", "" ) : config.timeout );
@@ -212,6 +212,8 @@ component accessors="true" {
 		var nextJob = variables.wirebox.getInstance( nextJobConfig.mapping );
 		param nextJobConfig.properties = {};
 
+		nextJob.setQueue( isNull( nextJobConfig.queue ) ? javacast( "null", "" ) : nextJobConfig.queue );
+		nextJob.setConnection( isNull( nextJobConfig.connection ) ? javacast( "null", "" ) : nextJobConfig.connection );
 		nextJob.setBackoff( isNull( nextJobConfig.backoff ) ? javacast( "null", "" ) : nextJobConfig.backoff );
 		nextJob.setTimeout( isNull( nextJobConfig.timeout ) ? javacast( "null", "" ) : nextJobConfig.timeout );
 		nextJob.setProperties( nextJobConfig.properties );


### PR DESCRIPTION
I think this will fix the issue of the queue not being passed along in the chain when it dispatches the next job. I noticed that the connection was also missing, so I added it. I tested with the queue, and it works for me. I did not try testing the connection. This works if you create a chain and specify a queue, and all the specified queues are the same. There is still an issue where if you mix and match queue names, it will not use the correct queue the first time it comes to the new queue name. It won't create the new job with the correct queue at that point, but rather use the queue of the prior job in the chain.