### PR TITLE
Fix incorrect throw that was causing raw HTML as the exception message

### DIFF
--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -150,10 +150,7 @@ component singleton accessors="true" {
 	public void function markAsFinished( required string id ) {
 		qb.table( variables.batchTableName )
 			.where( "id", arguments.id )
-			.update(
-				values = { "completedDate" : getCurrentUnixTimestamp() },
-				options = variables.defaultQueryOptions
-			);
+			.update( values = { "completedDate" : getCurrentUnixTimestamp() }, options = variables.defaultQueryOptions );
 	}
 
 	public void function cancel( required string id ) {

--- a/models/Providers/AbstractQueueProvider.cfc
+++ b/models/Providers/AbstractQueueProvider.cfc
@@ -165,7 +165,11 @@ component accessors="true" {
 					variables.log.debug( "Maximum attempts reached. Deleting job ###job.getId()#" );
 
 					if ( structKeyExists( job, "onFailure" ) ) {
-						invoke( job, "onFailure", { "excpetion": e } );
+						invoke(
+							job,
+							"onFailure",
+							{ "excpetion" : e }
+						);
 					}
 
 					variables.interceptorService.announce( "onCBQJobFailed", { "job" : job, "exception" : e } );

--- a/models/Providers/SyncProvider.cfc
+++ b/models/Providers/SyncProvider.cfc
@@ -109,7 +109,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 
 				variables.log.debug( "Deleted job ###job.getId()# after maximum failed attempts." );
 
-				throw( e );
+				rethrow;
 			}
 		}
 	}


### PR DESCRIPTION
I have been trying to track down the reason one user was seeing raw HTML as the logged message.  The issue is that `throw` treats the first positional argument as the message so Lucee was calling `toString()` on it, which would render the HTML error template.

I'm not sure this additional throw is even necessary as there is already error logging above it, with the exception, but performing a `rethrow` accomplishes desired result.