### PR TITLE
fix(Config): Worker Pools can only define a single queue to work.

### DIFF
--- a/models/BaseConfig.cfc
+++ b/models/BaseConfig.cfc
@@ -129,7 +129,7 @@ component singleton accessors="true" {
 		required string name,
 		string connectionName,
 		numeric quantity = 1,
-		array queues = [ "*" ],
+		string queue = "default",
 		boolean force = false
 	) {
 		var workerPoolDefinition = newWorkerPoolDefinitionInstance();
@@ -138,7 +138,7 @@ component singleton accessors="true" {
 			workerPoolDefinition.setConnectionName( arguments.connectionName );
 		}
 		workerPoolDefinition.setQuantity( arguments.quantity );
-		workerPoolDefinition.setQueues( arguments.queues );
+		workerPoolDefinition.setQueue( arguments.queue );
 		if ( variables.workerPoolDefinitions.keyExists( workerPoolDefinition.getName() ) && !arguments.force ) {
 			throw( "Duplicate Worker Pool name: [#workerPoolDefinition.getName()#]. Either use a different name or pass the `force` parameter to overwrite the existing Worker Pool." );
 		}
@@ -173,7 +173,7 @@ component singleton accessors="true" {
 			name = arguments.definition.getName(),
 			connectionName = arguments.definition.getConnectionName(),
 			quantity = arguments.definition.getQuantity(),
-			queues = arguments.definition.getQueues(),
+			queue = arguments.definition.getQueue(),
 			backoff = arguments.definition.getBackoff(),
 			timeout = arguments.definition.getTimeout(),
 			maxAttempts = arguments.definition.getMaxAttempts()
@@ -184,7 +184,7 @@ component singleton accessors="true" {
 		required string name,
 		required string connectionName,
 		numeric quantity = 1,
-		array queues = [ "*" ],
+		string queue = "default",
 		numeric backoff = 0,
 		numeric timeout = 60,
 		numeric maxAttempts = 1
@@ -194,7 +194,7 @@ component singleton accessors="true" {
 		instance.setConnectionName( arguments.connectionName );
 		instance.setConnection( getConnection( arguments.connectionName ) );
 		instance.setQuantity( arguments.quantity );
-		instance.setQueues( arguments.queues );
+		instance.setQueue( arguments.queue );
 		instance.setBackoff( arguments.backoff );
 		instance.setTimeout( arguments.timeout );
 		instance.setMaxAttempts( arguments.maxAttempts );

--- a/models/Providers/AbstractQueueProvider.cfc
+++ b/models/Providers/AbstractQueueProvider.cfc
@@ -237,7 +237,7 @@ component accessors="true" {
 		}
 
 		if ( !isNull( arguments.pool ) ) {
-			return arguments.pool.getQueues()[ 1 ];
+			return arguments.pool.getQueue();
 		}
 
 		return "default";

--- a/models/Workers/WorkerPool.cfc
+++ b/models/Workers/WorkerPool.cfc
@@ -4,16 +4,14 @@ component accessors="true" {
 
 	property name="name" type="string";
 	property name="quantity" default="1";
-	property name="queues" type="array";
+	property
+		name="queue"
+		type="string"
+		default="default";
 	property name="backoff" default="0";
 	property name="timeout" default="60";
 	property name="maxAttempts" default="1";
 
-	property
-		name="_shouldWorkAllQueues"
-		type="boolean"
-		default="true"
-		accessors="false";
 	property name="connectionName";
 	property name="connection";
 
@@ -24,14 +22,12 @@ component accessors="true" {
 
 	public WorkerPool function init() {
 		variables.workerHooks = [];
-		variables.queues = [ "*" ];
 		variables.currentExecutorCount = 0;
 		return this;
 	}
 
-	public WorkerPool function setQueues( required array queues ) {
-		variables.queues = arguments.queues;
-		variables._shouldWorkAllQueues = variables.queues.filter( ( queue ) => queue == "*" ).len() > 0;
+	public WorkerPool function setQueue( required string queue ) {
+		variables.queue = arguments.queue;
 		return this;
 	}
 
@@ -79,10 +75,6 @@ component accessors="true" {
 		return this
 	}
 
-	public boolean function shouldWorkAllQueues() {
-		return variables._shouldWorkAllQueues;
-	}
-
 	public WorkerPool function shutdown() {
 		for ( var i = variables.workerHooks.len(); i >= 1; i-- ) {
 			var stopWorkerFn = variables.workerHooks[ i ];
@@ -97,7 +89,7 @@ component accessors="true" {
 		return {
 			"name" : variables.name,
 			"quantity" : variables.quantity,
-			"queues" : variables.queues,
+			"queue" : variables.queue,
 			"backoff" : variables.backoff,
 			"timeout" : variables.timeout,
 			"maxAttempts" : variables.maxAttempts,

--- a/models/Workers/WorkerPoolDefinition.cfc
+++ b/models/Workers/WorkerPoolDefinition.cfc
@@ -22,10 +22,13 @@ component accessors="true" {
 	property name="quantity" default="1";
 
 	/**
-	 * An array of queues this Worker Pool will work, in order.
-	 * An asterisk (`*`) signifies all queues.
+	 * The queue name this Worker Pool will work
+	 * The default queue name is `default`.
 	 */
-	property name="queues" type="array";
+	property
+		name="queue"
+		type="string"
+		default="default";
 
 	/**
 	 * The time to wait between retrying jobs, in seconds.
@@ -48,7 +51,6 @@ component accessors="true" {
 	 * @returns A new WorkerPoolDefinition.
 	 */
 	public WorkerPoolDefinition function init() {
-		variables.queues = [ "*" ];
 		return this;
 	}
 
@@ -77,18 +79,14 @@ component accessors="true" {
 	}
 
 	/**
-	 * An array or list of queues to work, in order.
-	 * The asterisk (`*`) is a special symbol for all queues.
+	 * The name of a queue to work.
 	 *
-	 * @queues An array or list of queues to work, in order.
+	 * @queue The name of a queue to work.
 	 *
 	 * @returns The current WorkerPoolDefinition.
 	 */
-	public WorkerPoolDefinition function onQueues( required any queues ) {
-		if ( !isArray( arguments.queues ) ) {
-			arguments.queues = arraySlice( arguments.queues.split( ",\s*" ), 1 );
-		}
-		setQueues( arguments.queues );
+	public WorkerPoolDefinition function onQueue( required any queue ) {
+		setQueue( arguments.queue );
 		return this;
 	}
 

--- a/tests/specs/integration/ConfigSpec.cfc
+++ b/tests/specs/integration/ConfigSpec.cfc
@@ -65,7 +65,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					expect( defaultWorkerPool.getConnectionName() ).toBe( "default" );
 					expect( defaultWorkerPool.getConnection().getName() ).toBe( "default" );
 					expect( defaultWorkerPool.getQuantity() ).toBe( 1 );
-					expect( defaultWorkerPool.getQueues() ).toBe( [ "*" ] );
+					expect( defaultWorkerPool.getQueue() ).toBe( "default" );
 					expect( defaultWorkerPool.getBackoff() ).toBe( 0 );
 					expect( defaultWorkerPool.getTimeout() ).toBe( 60 );
 					expect( defaultWorkerPool.getMaxAttempts() ).toBe( 1 );
@@ -95,7 +95,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					var workerPoolDefinition = config.newWorkerPool( name = "default", force = true );
 					workerPoolDefinition.forConnection( "default" );
 					workerPoolDefinition.quantity( 4 );
-					workerPoolDefinition.onQueues( "default" );
+					workerPoolDefinition.onQueue( "emails" );
 					workerPoolDefinition.backoff( 5 );
 					workerPoolDefinition.timeout( 30 );
 					workerPoolDefinition.maxAttempts( 3 );
@@ -105,7 +105,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					expect( workerPool.getConnectionName() ).toBe( "default" );
 					expect( workerPool.getConnection().getName() ).toBe( "default" );
 					expect( workerPool.getQuantity() ).toBe( 4 );
-					expect( workerPool.getQueues() ).toBe( [ "default" ] );
+					expect( workerPool.getQueue() ).toBe( "emails" );
 					expect( workerPool.getBackoff() ).toBe( 5 );
 					expect( workerPool.getTimeout() ).toBe( 30 );
 					expect( workerPool.getMaxAttempts() ).toBe( 3 );


### PR DESCRIPTION
In order to work with new Queue Providers, the Worker Pools need to be updated to only work a specific queue.  This is becuase many future Queue Providers like RabbitMQ and Amazon SQS only support listening to a single queue in a consumer.  If you previously had multiple queues defined in a WorkerPool, you will need to define multiple WorkerPool instances, one for each of the queues. Additionally, there are no more wildcard queues.  Every queue you publish to must have a WorkerPool defined in order for that Job to be worked. Finally, queue priorities are defined by the number of workers (`quantity`) you define for the WorkerPool. WorkerPools can no longer share workers across queues.

BREAKING CHANGE: WorkerPools can only define a single queue to work.