### PR TITLE
v3.0.0

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -66,11 +66,11 @@ component {
 					"frequency" : ( task ) => {
 						task.everyDay();
 					},
-					"criteria" : ( q ) => {
+					"criteria" : ( q, currentUnixTimestamp ) => {
 						q.where(
 							"failedDate",
 							"<=",
-							dateAdd( "d", -30, now() )
+							currentUnixTimestamp - ( 60 * 60 * 24 * 30 )
 						); // 30 days
 					}
 				}

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -40,6 +40,7 @@ component {
 				"datasource" : "", // `datasource` can also be a struct.
 				"queryOptions" : {} // The sibling `datasource` property overrides any defined datasource in `queryOptions`.
 			},
+			// Flag to allow restricting Job interceptor execution using a `jobPattern` annotation.
 			"registerJobInterceptorRestrictionAspect" : false
 		};
 

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -23,6 +23,8 @@ component {
 			// The default amount of time, in seconds, to wait before timing out a job.
 			// Used if the connection and job doesn't define their own.
 			"defaultWorkerTimeout" : 60,
+			// The default amount of time, in seconds, to wait for tasks to complete before killing them when requesting a shutdown.
+			"defaultWorkerShutdownTimeout" : 60,
 			// The default amount of attempts to try before failing a job.
 			// Used if the connection and job doesn't define their own.
 			"defaultWorkerMaxAttempts" : 1,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A queue provider **must** extend the `AbstractQueueProvider` and implement the r
 Additionally, the Queue Provider can use the following hooks to do additional processing or cleanup:
 
 + `private void function beforeJobRun( required AbstractJob job )`
-+ `private void function afterJobFailed( required any id, AbstractJob job )`
++ `private void function afterJobFailed( required any id, AbstractJob job, WorkerPool pool )`
 
 ### Job
 A job is a CFC that follows the `IDispatchableJob` interface (easily done by extending the `AbstractJob` component). It defines how to serialize the job using a memento pattern and deserialize the job from the queue.  It also holds the data needed to execute the job and a `handle` method that is called when working the job from the queue.  Job components exist in the context of your application so you have access to all the models, services, and helpers you have already written.  (Raw string messages can also be dispatched via cbq.  The message will need to be handled directly by your queue worker.)
@@ -175,7 +175,7 @@ To dispatch a job to a queue to be worked, call the `dispatch` method on a `Job`
 Dispatching a job serializes it and sends it to the configured connection.  It will
 later be picked up by a worker and processed.
 
-```cfc  
+```cfc
 getInstance( "GreetingJob" ).dispatch();
 ```
 

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"3.0.0-beta.6",
+    "version":"3.0.0-beta.7",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"3.0.0-beta.12",
+    "version":"3.0.0-beta.13",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"3.0.0-beta.7",
+    "version":"3.0.0-beta.8",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"3.0.0-beta.3",
+    "version":"3.0.0-beta.6",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"3.0.0-beta.8",
+    "version":"3.0.0-beta.12",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"3.0.0-beta.13",
+    "version":"3.0.0-beta.14",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"3.0.0-beta.2",
+    "version":"3.0.0-beta.3",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"2.1.0",
+    "version":"3.0.0-beta.1",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"3.0.0-beta.1",
+    "version":"3.0.0-beta.2",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/config/Scheduler.cfc
+++ b/config/Scheduler.cfc
@@ -16,6 +16,31 @@ component {
             .setDisabled( variables.settings.scaleInterval <= 0 );
     }
 
+
+	function onShutdown( boolean force = false, numeric timeout = variables.shutdownTimeout ) {
+		systemOutput( "Shutting down cbq scheduler", true );
+		if ( variables.log.canDebug() ) {
+			variables.log.debug( "Shutting down cbq scheduler", {
+				"force": force,
+				"timeout": timeout
+			} );
+		}
+
+		var config = variables.wirebox.getInstance( "Config@cbq" );
+		var workerPoolMap = config.getWorkerPools();
+		for ( var workerPoolName in workerPoolMap ) {
+			var workerPool = workerPoolMap[ workerPoolName ];
+			workerPool.shutdown( argumentCollection = arguments );
+		}
+
+		if ( variables.log.canDebug() ) {
+			variables.log.debug( "Finished shutting down cbq scheduler", {
+				"force": force,
+				"timeout": timeout
+			} );
+		}
+	}
+
     function beforeAnyTask( task ) {
         if ( variables.log.canDebug() ) {
             variables.log.debug( "[#arguments.task.getName()#] starting on #getThreadName()#..." );

--- a/config/Scheduler.cfc
+++ b/config/Scheduler.cfc
@@ -119,12 +119,13 @@ component {
 		var cleanupTask = task( "cbq:db-cleanup-batches" )
 			.call( () => {
 				var deleteQuery = newQuery()
-                    .table( variables.settings.batchRepositoryProperties.tableName )
+                variables.settings.batchRepositoryProperties.cleanup.criteria( deleteQuery, getCurrentUnixTimestamp() );
+				// These restrictions are added after to prevent any mistakes from the user erasing them.
+				deleteQuery.table( variables.settings.batchRepositoryProperties.tableName )
                     .where( ( q2 ) => {
                         q2.whereNotNull( "cancelledDate" );
                         q2.orWhereNotNull( "completedDate" );
                     } );
-                variables.settings.batchRepositoryProperties.cleanup.criteria( deleteQuery, getCurrentUnixTimestamp() );
 				return deleteQuery.delete( options = options ).result.recordCount;
 			} )
 			.before( function() {

--- a/interceptors/LogFailedJobsInterceptor.cfc
+++ b/interceptors/LogFailedJobsInterceptor.cfc
@@ -1,6 +1,7 @@
 component {
 
 	property name="settings" inject="coldbox:moduleSettings:cbq";
+	property name="javaInstant" inject="java:java.time.Instant";
 	property name="qb" inject="provider:QueryBuilder@qb";
 	property name="config" inject="provider:Config@cbq";
 
@@ -59,11 +60,21 @@ component {
 					},
 					"exceptionStackTrace" : arguments.data.exception.stackTrace,
 					"exception" : serializeJSON( arguments.data.exception ),
-					"failedDate" : now(),
+					"failedDate" : getCurrentUnixTimestamp(),
 					"originalId" : arguments.data.job.getId()
 				},
 				options = options
 			);
+	}
+
+	/**
+	 * Get the "available at" UNIX timestamp.
+	 *
+	 * @delay  The delay, in seconds, to add to the current timestamp
+	 * @return int
+	 */
+	private numeric function getCurrentUnixTimestamp( numeric delay = 0 ) {
+		return variables.javaInstant.now().getEpochSecond() + arguments.delay;
 	}
 
 }

--- a/interceptors/LogFailedJobsInterceptor.cfc
+++ b/interceptors/LogFailedJobsInterceptor.cfc
@@ -59,7 +59,8 @@ component {
 					},
 					"exceptionStackTrace" : arguments.data.exception.stackTrace,
 					"exception" : serializeJSON( arguments.data.exception ),
-					"failedDate" : now()
+					"failedDate" : now(),
+					"originalId" : arguments.data.job.getId()
 				},
 				options = options
 			);

--- a/models/BaseConfig.cfc
+++ b/models/BaseConfig.cfc
@@ -176,6 +176,7 @@ component singleton accessors="true" {
 			queue = arguments.definition.getQueue(),
 			backoff = arguments.definition.getBackoff(),
 			timeout = arguments.definition.getTimeout(),
+			shutdownTimeout = arguments.definition.getShutdownTimeout(),
 			maxAttempts = arguments.definition.getMaxAttempts()
 		);
 	}
@@ -187,6 +188,7 @@ component singleton accessors="true" {
 		any queue = "default",
 		numeric backoff = 0,
 		numeric timeout = 60,
+		numeric shutdownTimeout = 60,
 		numeric maxAttempts = 1
 	) {
 		var instance = newWorkerPoolInstance();
@@ -197,6 +199,7 @@ component singleton accessors="true" {
 		instance.setQueue( arguments.queue );
 		instance.setBackoff( arguments.backoff );
 		instance.setTimeout( arguments.timeout );
+		instance.setShutdownTimeout( arguments.shutdownTimeout );
 		instance.setMaxAttempts( arguments.maxAttempts );
 
 		if ( structKeyExists( variables.workerPools, arguments.name ) ) {

--- a/models/Jobs/AbstractJob.cfc
+++ b/models/Jobs/AbstractJob.cfc
@@ -184,4 +184,10 @@ component accessors="true" {
 		return this;
 	}
 
+	private boolean function checkInterrupted() {
+		var thisThread = createObject( "java", "java.lang.Thread" ).currentThread();
+		// Has the user tried to interrupt this thread?
+		return thisThread.interrupted();
+	}
+
 }

--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -205,7 +205,7 @@ component singleton accessors="true" {
 	 * @delay  The delay, in seconds, to add to the current timestamp
 	 * @return int
 	 */
-	public numeric function getCurrentUnixTimestamp( numeric delay = 0 ) {
+	public date function getCurrentUnixTimestamp( numeric delay = 0 ) {
 		return variables.javaInstant.now().getEpochSecond() + arguments.delay;
 	}
 

--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -205,7 +205,7 @@ component singleton accessors="true" {
 	 * @delay  The delay, in seconds, to add to the current timestamp
 	 * @return int
 	 */
-	public date function getCurrentUnixTimestamp( numeric delay = 0 ) {
+	public numeric function getCurrentUnixTimestamp( numeric delay = 0 ) {
 		return variables.javaInstant.now().getEpochSecond() + arguments.delay;
 	}
 

--- a/models/Jobs/Dispatcher.cfc
+++ b/models/Jobs/Dispatcher.cfc
@@ -21,11 +21,12 @@ component singleton accessors="true" {
 			}
 		);
 
+		arguments.job.setCurrentAttempt( 0 );
 		connection.push(
 			queueName = queueName,
 			payload = serializeJSON( arguments.job.getMemento() ),
 			delay = delay,
-			attempts = 1 // TODO: shouldn't this be 0?
+			attempts = 0
 		);
 
 		return this;
@@ -50,10 +51,11 @@ component singleton accessors="true" {
 				}
 			);
 
+			job.setCurrentAttempt( 0 );
 			connection.push(
 				queueName = queueName,
 				payload = serializeJSON( job.getMemento() ),
-				attempts = 1
+				attempts = 0
 			);
 		}
 

--- a/models/Providers/AbstractQueueProvider.cfc
+++ b/models/Providers/AbstractQueueProvider.cfc
@@ -102,6 +102,7 @@ component accessors="true" {
 		required WorkerPool pool,
 		function afterJobHook
 	) {
+		arguments.job.setCurrentAttempt( arguments.job.getCurrentAttempt() + 1 );
 		return variables.async
 			.newFuture( function() {
 				if ( variables.log.canDebug() ) {

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -66,7 +66,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 			} )
 			.onSuccess( function( task, jobCount ) {
 				if ( variables.log.canDebug() ) {
-					variables.log.debug( "Finished fetching jobs from the db for Worker Pool [#pool.getUniqueId()#].  Total jobs retrieved: #jobCount#" );
+					variables.log.debug( "Finished fetching jobs from the db for Worker Pool [#pool.getUniqueId()#].  Total jobs retrieved: #jobCount.orElse( 0 )#" );
 				}
 			} )
 			.onFailure( function( task, exception ) {

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -356,7 +356,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 						"null" : true,
 						"nulls" : true
 					},
-					"availableDate" : getCurrentUnixTimestamp( getBackoffForJob( arguments.job, arguments.pool ) ),
+					"availableDate" : getCurrentUnixTimestamp( getTimeoutForJob( arguments.job, arguments.pool ) ),
 					"reservedDate" : {
 						"value" : "",
 						"null" : true,

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -232,23 +232,6 @@ component accessors="true" extends="AbstractQueueProvider" {
 		// deleteJobById( arguments.id );
 	}
 
-	private void function deleteJobById( required numeric id ) {
-		transaction {
-			if (
-				!newQuery()
-					.table( variables.tableName )
-					.lockForUpdate()
-					.find( id = arguments.id, options = variables.defaultQueryOptions )
-					.isEmpty()
-			) {
-				newQuery()
-					.table( variables.tableName )
-					.where( "id", arguments.id )
-					.delete( options = variables.defaultQueryOptions );
-			}
-		}
-	}
-
 	private void function markJobAsCompletedById( required numeric id, required WorkerPool pool ) {
 		newQuery()
 			.table( variables.tableName )

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -393,13 +393,21 @@ component accessors="true" extends="AbstractQueueProvider" {
 							variables.getCurrentUnixTimestamp()
 						);
 				} );
-				// is reserved but expired
-				q1.orWhere( ( q4 ) => {
-					q4.where(
-						"reservedDate",
-						"<=",
-						variables.getCurrentUnixTimestamp() - pool.getTimeout()
-					);
+				// past the reserved date
+				q1.orWhere(
+					"reservedDate",
+					"<=",
+					variables.getCurrentUnixTimestamp() - pool.getTimeout()
+				);
+				// reserved by a worker but never released
+				q1.orWhere( ( q3 ) => {
+					q3.whereNull( "reservedDate" )
+						.whereNotNull( "reservedBy" )
+						.where(
+							"availableDate",
+							"<=",
+							variables.getCurrentUnixTimestamp()
+						);
 				} );
 			} )
 			.orderByRaw( "CASE WHEN reservedBy = ? THEN 1 ELSE 2 END ASC", [ arguments.pool.getUniqueId() ] )

--- a/models/Providers/SyncProvider.cfc
+++ b/models/Providers/SyncProvider.cfc
@@ -89,10 +89,10 @@ component accessors="true" extends="AbstractQueueProvider" {
 			if ( structKeyExists( job, "after" ) ) {
 				job.after();
 			}
-			afterJobRun( job );
+			afterJobRun( job, pool );
 
-			ensureSuccessfulBatchJobIsRecorded( job );
-			dispatchNextJobInChain( job );
+			ensureSuccessfulBatchJobIsRecorded( job, pool );
+			dispatchNextJobInChain( job, pool );
 		} catch ( any e ) {
 			// log failed job
 			if ( log.canError() ) {

--- a/models/Workers/WorkerPool.cfc
+++ b/models/Workers/WorkerPool.cfc
@@ -2,6 +2,7 @@ component accessors="true" {
 
 	property name="async" inject="coldbox:asyncManager";
 
+	property name="id" type="string";
 	property name="name" type="string";
 	property name="quantity" default="1";
 	property
@@ -21,9 +22,14 @@ component accessors="true" {
 
 
 	public WorkerPool function init() {
+		variables.id = createUUID();
 		variables.workerHooks = [];
 		variables.currentExecutorCount = 0;
 		return this;
+	}
+
+	public string function getUniqueId() {
+		return variables.name & "/" & variables.id;
 	}
 
 	public WorkerPool function setQueue( required any queue ) {
@@ -98,7 +104,9 @@ component accessors="true" {
 
 	public struct function getMemento() {
 		return {
+			"id" : variables.id,
 			"name" : variables.name,
+			"uniqueId" : getUniqueId(),
 			"quantity" : variables.quantity,
 			"queue" : variables.queue,
 			"backoff" : variables.backoff,

--- a/models/Workers/WorkerPool.cfc
+++ b/models/Workers/WorkerPool.cfc
@@ -11,6 +11,7 @@ component accessors="true" {
 		default="default";
 	property name="backoff" default="0";
 	property name="timeout" default="60";
+	property name="shutdownTimeout" default="60";
 	property name="maxAttempts" default="1";
 
 	property name="connectionName";
@@ -20,13 +21,11 @@ component accessors="true" {
 	property name="executor";
 	property name="currentExecutorCount";
 
-	property name="shutdownTimeout";
 
 	public WorkerPool function init() {
 		variables.id = createUUID();
 		variables.workerHooks = [];
 		variables.currentExecutorCount = 0;
-		variables.shutdownTimeout = 30;
 		return this;
 	}
 

--- a/models/Workers/WorkerPool.cfc
+++ b/models/Workers/WorkerPool.cfc
@@ -20,11 +20,13 @@ component accessors="true" {
 	property name="executor";
 	property name="currentExecutorCount";
 
+	property name="shutdownTimeout";
 
 	public WorkerPool function init() {
 		variables.id = createUUID();
 		variables.workerHooks = [];
 		variables.currentExecutorCount = 0;
+		variables.shutdownTimeout = 30;
 		return this;
 	}
 
@@ -92,13 +94,20 @@ component accessors="true" {
 		return this
 	}
 
-	public WorkerPool function shutdown() {
+	public WorkerPool function shutdown( boolean force = false, numeric timeout = variables.shutdownTimeout ) {
 		for ( var i = variables.workerHooks.len(); i >= 1; i-- ) {
 			var stopWorkerFn = variables.workerHooks[ i ];
 			stopWorkerFn();
 			arrayDeleteAt( variables.workerHooks, i );
 		}
 		setQuantity( 0 );
+		if ( !isNull( variables.executor ) ) {
+			if ( arguments.force ) {
+				variables.executor.shutdownNow();
+			} else {
+				variables.executor.shutdownAndAwaitTermination( arguments.timeout );
+			}
+		}
 		return this;
 	}
 

--- a/models/Workers/WorkerPoolDefinition.cfc
+++ b/models/Workers/WorkerPoolDefinition.cfc
@@ -41,6 +41,11 @@ component accessors="true" {
 	property name="timeout" inject="coldbox:moduleSettings:cbq:defaultWorkerTimeout";
 
 	/**
+	 * The maximum amount of time to wait for jobs to complete when requesting a shutdown, like for a ColdBox reinit, in seconds.
+	 */
+	property name="shutdownTimeout" inject="coldbox:moduleSettings:cbq:defaultWorkerShutdownTimeout";
+
+	/**
 	 * The maximum number of attempts made before a job is marked as failed.
 	 */
 	property name="maxAttempts" inject="coldbox:moduleSettings:cbq:defaultWorkerMaxAttempts";
@@ -93,7 +98,7 @@ component accessors="true" {
 	/**
 	 * Sets the backoff time amount, in seconds.
 	 *
-	 * @count The backoff time amount, in seconds.
+	 * @amount The backoff time amount, in seconds.
 	 *
 	 * @returns The current WorkerPoolDefinition.
 	 */
@@ -105,12 +110,24 @@ component accessors="true" {
 	/**
 	 * Sets the timeout time amount, in seconds.
 	 *
-	 * @count The timeout time amount, in seconds.
+	 * @amount The timeout time amount, in seconds.
 	 *
 	 * @returns The current WorkerPoolDefinition.
 	 */
 	public WorkerPoolDefinition function timeout( required numeric amount ) {
 		setTimeout( arguments.amount );
+		return this;
+	}
+
+	/**
+	 * Sets the shutdown timeout time amount, in seconds.
+	 *
+	 * @amount The shutdown timeout time amount, in seconds.
+	 *
+	 * @returns The current WorkerPoolDefinition.
+	 */
+	public WorkerPoolDefinition function shutdownTimeout( required numeric amount ) {
+		setShutdownTimeout( arguments.amount );
 		return this;
 	}
 

--- a/resources/database/migrations/2000_01_01_000000_create_cbq_jobs_table.cfc
+++ b/resources/database/migrations/2000_01_01_000000_create_cbq_jobs_table.cfc
@@ -6,9 +6,9 @@ component {
             t.string( "queue" );
             t.longText( "payload" );
             t.unsignedTinyInteger( "attempts" );
-            t.unsignedInteger( "reservedDate" ).nullable();
-            t.unsignedInteger( "availableDate" );
-            t.unsignedInteger( "createdDate" );
+            t.unsignedBigInteger( "reservedDate" ).nullable();
+            t.unsignedBigInteger( "availableDate" );
+            t.unsignedBigInteger( "createdDate" );
 
 			t.index( "queue" );
         } );

--- a/resources/database/migrations/2000_01_01_000003_add_reserverdBy_to_cbq_jobs_table.cfc
+++ b/resources/database/migrations/2000_01_01_000003_add_reserverdBy_to_cbq_jobs_table.cfc
@@ -1,0 +1,17 @@
+component {
+
+    function up( schema ) {
+        schema.alter( "cbq_jobs", ( t ) => {
+            t.addColumn( t.string( "reservedBy" ).nullable() );
+			t.addConstraint( t.index( "reservedBy" ) );
+        } );
+    }
+
+    function down( schema ) {
+        schema.alter( "cbq_jobs", ( t ) => {
+			t.dropConstraint( t.index( "reservedBy" ) );
+            t.dropColumn( "reservedBy" );
+        } );
+    }
+
+}

--- a/resources/database/migrations/2000_01_01_000003_add_reserverdBy_to_cbq_jobs_table.cfc
+++ b/resources/database/migrations/2000_01_01_000003_add_reserverdBy_to_cbq_jobs_table.cfc
@@ -3,13 +3,13 @@ component {
     function up( schema ) {
         schema.alter( "cbq_jobs", ( t ) => {
             t.addColumn( t.string( "reservedBy" ).nullable() );
-			t.addConstraint( t.index( "reservedBy" ) );
+			t.addIndex( t.index( "reservedBy" ) );
         } );
     }
 
     function down( schema ) {
         schema.alter( "cbq_jobs", ( t ) => {
-			t.dropConstraint( t.index( "reservedBy" ) );
+			t.dropIndex( t.index( "reservedBy" ) );
             t.dropColumn( "reservedBy" );
         } );
     }

--- a/resources/database/migrations/2000_01_01_000004_normalize_timestamps.cfc
+++ b/resources/database/migrations/2000_01_01_000004_normalize_timestamps.cfc
@@ -1,0 +1,21 @@
+component {
+
+    function up( schema, qb ) {
+        schema.alter( "cbq_jobs", ( t ) => {
+            t.addColumn( t.unsignedBigInteger( "completedDate" ).nullable() );
+            t.addColumn( t.unsignedBigInteger( "lastReleasedDate" ).nullable() );
+            t.addColumn( t.unsignedBigInteger( "failedDate" ).nullable() );
+			t.addIndex( t.index( [ "completedDate", "failedDate" ] ) );
+        } );
+    }
+
+    function down( schema, qb ) {
+        schema.alter( "cbq_jobs", ( t ) => {
+			t.dropIndex( t.index( [ "completedDate", "failedDate" ] ) );
+            t.dropColumn( "failedDate" );
+            t.dropColumn( "lastReleasedDate" );
+            t.dropColumn( "completedDate" );
+        } );
+    }
+
+}

--- a/resources/database/migrations/2000_01_01_000005_track_failed_job_original_id.cfc
+++ b/resources/database/migrations/2000_01_01_000005_track_failed_job_original_id.cfc
@@ -1,0 +1,17 @@
+component {
+
+    function up( schema, qb ) {
+        schema.alter( "cbq_failed_jobs", ( t ) => {
+            t.addColumn( t.unsignedBigInteger( "originalId" ).nullable() );
+			t.addConstraint( t.foreignKey( "originalId", "fk_cbq_jobs_originalId" ).references( "id" ).onTable( "cbq_jobs" ).onDelete( "NO ACTION" ) );
+        } );
+    }
+
+    function down( schema, qb ) {
+        schema.alter( "cbq_failed_jobs", ( t ) => {
+			t.dropForeignKey( "fk_cbq_jobs_originalId" );
+            t.dropColumn( "originalId" );
+        } );
+    }
+
+}

--- a/resources/database/migrations/2000_01_01_000006_use_unix_timestamp_for_failed_job_log_failedDate.cfc
+++ b/resources/database/migrations/2000_01_01_000006_use_unix_timestamp_for_failed_job_log_failedDate.cfc
@@ -1,0 +1,25 @@
+component {
+
+    function up( schema, qb ) {
+        if ( qb.newQuery().table( "cbq_failed_jobs" ).count() > 0 ) {
+            throw( "To run this migration, the cbq_failed_jobs table must be empty." );
+        }
+
+        schema.alter( "cbq_failed_jobs", ( t ) => {
+            t.dropColumn( "failedDate" );
+            t.addColumn( t.unsignedInteger( "failedDate" ) );
+        } );
+    }
+
+    function down( schema, qb ) {
+        if ( qb.newQuery().table( "cbq_failed_jobs" ).count() > 0 ) {
+            throw( "To run this migration, the cbq_failed_jobs table must be empty." );
+        }
+
+        schema.alter( "cbq_failed_jobs", ( t ) => {
+            t.dropColumn( "failedDate" );
+            t.addColumn( t.timestamp( "failedDate" ).withCurrent() );
+        } );
+    }
+
+}

--- a/tests/resources/AbstractQueueProviderSpec.cfc
+++ b/tests/resources/AbstractQueueProviderSpec.cfc
@@ -12,7 +12,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 $spy( provider, "releaseJob" );
                 var workerPool = makeWorkerPool( provider );
                 var job = getInstance( "ReleaseTestJob" )
-                    .setCurrentAttempt( 1 )
+                    .setCurrentAttempt( 0 )
                     .setId( randRange( 1, 1000 ) )
                     .setMaxAttempts( 2 );
 


### PR DESCRIPTION
- fix(DBProvider): Better locking to avoid duplicate runs of the same job
- v3.0.0-beta.1
- chore(DBProvider): Remove `lockForUpdate` flag and add debug logging
- fix(DBProvider): Fix for unwrapping an Optional in a log message
- fix(WorkerPool): Correctly shutdown worker pools
- feat(WorkerPool): Make shutdown timeout configurable
- feat: Add clean-up tasks for completed or failed jobs, failed job logs, and completed or cancelled batches.
- fix(FailedJobs): Use a unix timestamp as the failed job log failedDate column type
- fix(DBProvider): When claiming a job, the DBProvider should extend the availableDate by the job timeout, not backoff.
- fix(DBProvider): Allow picking up of jobs that were previously reserved but not released correctly
