### PR TITLE
Update syntax for Lucee 6.1 and ACF

### DIFF
--- a/config/Scheduler.cfc
+++ b/config/Scheduler.cfc
@@ -44,9 +44,10 @@ component {
     }
 
     private any function registerCleanupFailedJobLogTask() {
-        param variables.settings.logFailedJobsProperties.cleanup.criteria = function( q, currentUnixTimestamp ) {
+		var cleanupCriteria = function( q, currentUnixTimestamp ) {
 			q.where( "failedDate", "<=", currentUnixTimestamp - ( 60 * 60 * 24 * 30 ) ); // 30 days
 		};
+		param variables.settings.logFailedJobsProperties.cleanup.criteria = cleanupCriteria;
 
         param variables.settings.logFailedJobsProperties.tableName = "cbq_failed_jobs";
 
@@ -90,18 +91,19 @@ component {
 				}
 			} );
 
-        param variables.settings.logFailedJobsProperties.cleanup.frequency = function( task ) { task.everyDay(); };
+		var cleanupFrequency = function( task ) { task.everyDay(); };
+		param variables.settings.logFailedJobsProperties.cleanup.frequency = cleanupFrequency;
 		variables.settings.logFailedJobsProperties.cleanup.frequency( cleanupTask );
     }
 
     private any function registerCleanupBatchJobsTask() {
-        param variables.settings.batchRepositoryProperties.cleanup.criteria = function( q, currentUnixTimestamp ) {
+		var cleanupCriteria = function( q, currentUnixTimestamp ) {
 			q.where( ( q3 ) => {
                 q3.where( "cancelledDate", "<=", currentUnixTimestamp - ( 60 * 60 * 24 * 30 ) ); // 30 days
                 q3.orWhere( "completedDate", "<=", currentUnixTimestamp - ( 60 * 60 * 24 * 30 ) ); // 30 week
             } );
 		};
-
+		param variables.settings.batchRepositoryProperties.cleanup.criteria = cleanupCriteria;
         param variables.settings.batchRepositoryProperties.tableName = "cbq_batches";
 
         var options = {};
@@ -150,7 +152,8 @@ component {
 				}
 			} );
 
-        param variables.settings.batchRepositoryProperties.cleanup.frequency = function( task ) { task.everyDay(); };
+        var cleanupFrequency = function( task ) { task.everyDay(); };
+		param variables.settings.batchRepositoryProperties.cleanup.frequency = cleanupFrequency;
 		variables.settings.batchRepositoryProperties.cleanup.frequency( cleanupTask );
     }
 

--- a/config/Scheduler.cfc
+++ b/config/Scheduler.cfc
@@ -158,7 +158,8 @@ component {
     }
 
 	function onShutdown( boolean force = false, numeric timeout = variables.settings.defaultWorkerShutdownTimeout ) {
-		systemOutput( "Shutting down cbq scheduler", true );
+		var stdout = createObject( "java", "java.lang.System" ).out;
+		stdout.println( "Shutting down cbq scheduler" );
 		if ( variables.log.canDebug() ) {
 			variables.log.debug( "Shutting down cbq scheduler", {
 				"force": force,


### PR DESCRIPTION
Tests failing on Lucee 6.1 and ACF 2023 due to unsupported syntax

Fixes Error on Lucee 6.1
Type lucee/runtime/type/Closure not present

Fixes Error on ACF 2023
You cannot use a variable reference with "." operators in this context

No functionality changes.

BTW: I wasn't sure what indentation to use - that file has a mix of tabs and spaces and running `box fmt` changed other lines and files.