### PR TITLE
Typo in AbstractQueueProvider.cfc exception handler

### DIFF
--- a/models/Providers/AbstractQueueProvider.cfc
+++ b/models/Providers/AbstractQueueProvider.cfc
@@ -209,7 +209,7 @@ component accessors="true" {
 						invoke(
 							job,
 							"onFailure",
-							{ "excpetion" : e }
+							{ "exception" : e }
 						);
 					}
 


### PR DESCRIPTION
Replace typo **excpetion** with exception.