### PR TITLE
fix: harden DBProvider against runaway retries and swallowed failures

### DIFF
--- a/.github/mysql/init/01-auth-plugin.sql
+++ b/.github/mysql/init/01-auth-plugin.sql
@@ -1,2 +1,0 @@
-ALTER USER 'cbq'@'%' IDENTIFIED WITH mysql_native_password BY 'cbq';
-FLUSH PRIVILEGES;

--- a/.github/mysql/init/01-auth-plugin.sql
+++ b/.github/mysql/init/01-auth-plugin.sql
@@ -1,0 +1,2 @@
+ALTER USER 'cbq'@'%' IDENTIFIED WITH mysql_native_password BY 'cbq';
+FLUSH PRIVILEGES;

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,7 +25,7 @@ jobs:
             experimental: true
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_RANDOM_ROOT_PASSWORD: yes
           MYSQL_USER: cbq
@@ -33,7 +33,7 @@ jobs:
           MYSQL_DATABASE: cbq
         ports:
           - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,6 +31,8 @@ jobs:
           MYSQL_USER: cbq
           MYSQL_PASSWORD: cbq
           MYSQL_DATABASE: cbq
+        volumes:
+          - ./.github/mysql/init/01-auth-plugin.sql:/docker-entrypoint-initdb.d/01-auth-plugin.sql:ro
         ports:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,7 +33,7 @@ jobs:
           MYSQL_DATABASE: cbq
         ports:
           - 3306
-        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -27,12 +27,10 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_RANDOM_ROOT_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: root
           MYSQL_USER: cbq
           MYSQL_PASSWORD: cbq
           MYSQL_DATABASE: cbq
-        volumes:
-          - ./.github/mysql/init/01-auth-plugin.sql:/docker-entrypoint-initdb.d/01-auth-plugin.sql:ro
         ports:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -57,6 +55,10 @@ jobs:
           box config set modules.commandbox-dotenv.checkEnvPreServerStart=false
           box install ${{ matrix.coldbox }} --noSave
           box package list
+
+      - name: Configure MySQL user auth plugin
+        run: |
+          mysql -h 127.0.0.1 -P ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "ALTER USER 'cbq'@'%' IDENTIFIED WITH mysql_native_password BY 'cbq'; FLUSH PRIVILEGES;"
 
       - name: Start server
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,8 @@ jobs:
           MYSQL_USER: cbq
           MYSQL_PASSWORD: cbq
           MYSQL_DATABASE: cbq
+        volumes:
+          - ./.github/mysql/init/01-auth-plugin.sql:/docker-entrypoint-initdb.d/01-auth-plugin.sql:ro
         ports:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
         cfengine: ["lucee@5", "lucee@6", "adobe@2021", "adobe@2023", "adobe@2025"]
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_RANDOM_ROOT_PASSWORD: yes
           MYSQL_USER: cbq
@@ -30,7 +30,7 @@ jobs:
           MYSQL_DATABASE: cbq
         ports:
           - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
           MYSQL_DATABASE: cbq
         ports:
           - 3306
-        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,12 +24,10 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_RANDOM_ROOT_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: root
           MYSQL_USER: cbq
           MYSQL_PASSWORD: cbq
           MYSQL_DATABASE: cbq
-        volumes:
-          - ./.github/mysql/init/01-auth-plugin.sql:/docker-entrypoint-initdb.d/01-auth-plugin.sql:ro
         ports:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -53,6 +51,10 @@ jobs:
           box install
           box config set modules.commandbox-dotenv.checkEnvPreServerStart=false
           box package list
+
+      - name: Configure MySQL user auth plugin
+        run: |
+          mysql -h 127.0.0.1 -P ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "ALTER USER 'cbq'@'%' IDENTIFIED WITH mysql_native_password BY 'cbq'; FLUSH PRIVILEGES;"
 
       - name: Start server
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         cfengine: ["lucee@5", "lucee@6", "adobe@2021", "adobe@2023", "adobe@2025"]
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_RANDOM_ROOT_PASSWORD: yes
           MYSQL_USER: cbq
@@ -25,7 +25,7 @@ jobs:
           MYSQL_DATABASE: cbq
         ports:
           - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           MYSQL_DATABASE: cbq
         ports:
           - 3306
-        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,10 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_RANDOM_ROOT_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: root
           MYSQL_USER: cbq
           MYSQL_PASSWORD: cbq
           MYSQL_DATABASE: cbq
-        volumes:
-          - ./.github/mysql/init/01-auth-plugin.sql:/docker-entrypoint-initdb.d/01-auth-plugin.sql:ro
         ports:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -48,6 +46,10 @@ jobs:
           box install
           box config set modules.commandbox-dotenv.checkEnvPreServerStart=false
           box package list
+
+      - name: Configure MySQL user auth plugin
+        run: |
+          mysql -h 127.0.0.1 -P ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "ALTER USER 'cbq'@'%' IDENTIFIED WITH mysql_native_password BY 'cbq'; FLUSH PRIVILEGES;"
 
       - name: Start server
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
           MYSQL_USER: cbq
           MYSQL_PASSWORD: cbq
           MYSQL_DATABASE: cbq
+        volumes:
+          - ./.github/mysql/init/01-auth-plugin.sql:/docker-entrypoint-initdb.d/01-auth-plugin.sql:ro
         ports:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"6.0.0-beta.2",
+    "version":"6.0.0-beta.3",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -31,9 +31,9 @@
         "cfmigrations":"modules/cfmigrations/"
     },
     "scripts":{
-        "format":"cfformat run ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc --overwrite",
-        "format:check":"cfformat check ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc --verbose",
-        "format:watch":"cfformat watch ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc",
+        "format":"cfformat run ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc,tests/resources/app/models/**/*.cfc --overwrite",
+        "format:check":"cfformat check ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc,tests/resources/app/models/**/*.cfc --verbose",
+        "format:watch":"cfformat watch ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc,tests/resources/app/models/**/*.cfc",
         "install:2021":"cfpm install document,feed,zip"
     },
     "ignore":[

--- a/box.json
+++ b/box.json
@@ -31,9 +31,9 @@
         "cfmigrations":"modules/cfmigrations/"
     },
     "scripts":{
-        "format":"cfformat run ModuleConfig.cfc,models/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc --overwrite",
-        "format:check":"cfformat check ModuleConfig.cfc,models/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc --verbose",
-        "format:watch":"cfformat watch ModuleConfig.cfc,models/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc",
+        "format":"cfformat run ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc --overwrite",
+        "format:check":"cfformat check ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc --verbose",
+        "format:watch":"cfformat watch ModuleConfig.cfc,models/**/*.cfc,interceptors/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc",
         "install:2021":"cfpm install document,feed,zip"
     },
     "ignore":[

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"5.0.7",
+    "version":"6.0.0-beta.1",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbq",
-    "version":"6.0.0-beta.1",
+    "version":"6.0.0-beta.2",
     "author":"Eric Peterson <eric@elpete.com>",
     "location":"forgeboxStorage",
     "homepage":"https://github.com/coldbox-modules/cbq",

--- a/interceptors/LogFailedJobsInterceptor.cfc
+++ b/interceptors/LogFailedJobsInterceptor.cfc
@@ -45,7 +45,7 @@ component {
 				"nulls" : ( arguments.data.exception.type ?: "" ) == ""
 			},
 			"exceptionMessage" : {
-				"value": arguments.data.exception.message ?: "",
+				"value" : arguments.data.exception.message ?: "",
 				"cfsqltype" : "CF_SQL_VARCHAR",
 				"null" : ( arguments.data.exception.message ?: "" ) == "",
 				"nulls" : ( arguments.data.exception.message ?: "" ) == ""
@@ -63,27 +63,37 @@ component {
 				"nulls" : ( arguments.data.exception.extendedInfo ?: "" ) == ""
 			},
 			"exceptionStackTrace" : {
-				"value": arguments.data.exception.stackTrace ?: "",
+				"value" : isNull( arguments.data.exception.stackTrace ) ? "" : (
+					isSimpleValue( arguments.data.exception.stackTrace ) ? arguments.data.exception.stackTrace : serializeJSON(
+						arguments.data.exception.stackTrace
+					)
+				),
 				"cfsqltype" : "CF_SQL_VARCHAR",
-				"null" : ( arguments.data.exception.stackTrace ?: "" ) == "",
-				"nulls" : ( arguments.data.exception.stackTrace ?: "" ) == ""
+				"null" : isNull( arguments.data.exception.stackTrace ) || (
+					isSimpleValue( arguments.data.exception.stackTrace ) && arguments.data.exception.stackTrace == ""
+				),
+				"nulls" : isNull( arguments.data.exception.stackTrace ) || (
+					isSimpleValue( arguments.data.exception.stackTrace ) && arguments.data.exception.stackTrace == ""
+				)
 			},
-			"exception" : isNull( arguments.data.exception ) ? javacast( "null", "" ) : serializeJSON( arguments.data.exception ),
-			"failedDate" : { "value": getCurrentUnixTimestamp(), "cfsqltype": "CF_SQL_BIGINT" },
-			"originalId" : { "value": arguments.data.job.getId(), "cfsqltype": "CF_SQL_VARCHAR" }
+			"exception" : isNull( arguments.data.exception ) ? javacast( "null", "" ) : serializeJSON(
+				arguments.data.exception
+			),
+			"failedDate" : {
+				"value" : getCurrentUnixTimestamp(),
+				"cfsqltype" : "CF_SQL_BIGINT"
+			},
+			"originalId" : {
+				"value" : arguments.data.job.getId(),
+				"cfsqltype" : "CF_SQL_VARCHAR"
+			}
 		};
 
 		try {
 			qb.table( variables.settings.logFailedJobsProperties.tableName )
-				.insert(
-					values = logData,
-					options = options
-				);
+				.insert( values = logData, options = options );
 		} catch ( any e ) {
-			log.error( "Failed to log failed job: #e.message#", {
-				"log": logData,
-				"exception": e
-			} );
+			log.error( "Failed to log failed job: #e.message#", { "log" : logData, "exception" : e } );
 			rethrow;
 		}
 	}

--- a/interceptors/LogFailedJobsInterceptor.cfc
+++ b/interceptors/LogFailedJobsInterceptor.cfc
@@ -44,7 +44,12 @@ component {
 				"null" : ( arguments.data.exception.type ?: "" ) == "",
 				"nulls" : ( arguments.data.exception.type ?: "" ) == ""
 			},
-			"exceptionMessage" : arguments.data.exception.message,
+			"exceptionMessage" : {
+				"value": arguments.data.exception.message ?: "",
+				"cfsqltype" : "CF_SQL_VARCHAR",
+				"null" : ( arguments.data.exception.message ?: "" ) == "",
+				"nulls" : ( arguments.data.exception.message ?: "" ) == ""
+			},
 			"exceptionDetail" : {
 				"value" : arguments.data.exception.detail ?: "",
 				"cfsqltype" : "CF_SQL_VARCHAR",
@@ -57,8 +62,13 @@ component {
 				"null" : ( arguments.data.exception.extendedInfo ?: "" ) == "",
 				"nulls" : ( arguments.data.exception.extendedInfo ?: "" ) == ""
 			},
-			"exceptionStackTrace" : arguments.data.exception.stackTrace,
-			"exception" : serializeJSON( arguments.data.exception ),
+			"exceptionStackTrace" : {
+				"value": arguments.data.exception.stackTrace ?: "",
+				"cfsqltype" : "CF_SQL_VARCHAR",
+				"null" : ( arguments.data.exception.stackTrace ?: "" ) == "",
+				"nulls" : ( arguments.data.exception.stackTrace ?: "" ) == ""
+			},
+			"exception" : isNull( arguments.data.exception ) ? javacast( "null", "" ) : serializeJSON( arguments.data.exception ),
 			"failedDate" : { "value": getCurrentUnixTimestamp(), "cfsqltype": "CF_SQL_BIGINT" },
 			"originalId" : { "value": arguments.data.job.getId(), "cfsqltype": "CF_SQL_VARCHAR" }
 		};

--- a/interceptors/LogFailedJobsInterceptor.cfc
+++ b/interceptors/LogFailedJobsInterceptor.cfc
@@ -36,8 +36,14 @@ component {
 			"connection" : connectionName,
 			"queue" : queueName,
 			"mapping" : arguments.data.job.getMapping(),
-			"memento" : serializeJSON( arguments.data.job.getMemento() ),
-			"properties" : serializeJSON( arguments.data.job.getProperties() ),
+			"memento" : {
+				"value" : serializeJSON( arguments.data.job.getMemento() ),
+				"cfsqltype" : "CF_SQL_LONGVARCHAR"
+			},
+			"properties" : {
+				"value" : serializeJSON( arguments.data.job.getProperties() ),
+				"cfsqltype" : "CF_SQL_LONGVARCHAR"
+			},
 			"exceptionType" : {
 				"value" : arguments.data.exception.type ?: "",
 				"cfsqltype" : "CF_SQL_VARCHAR",
@@ -58,7 +64,7 @@ component {
 			},
 			"exceptionExtendedInfo" : {
 				"value" : arguments.data.exception.extendedInfo ?: "",
-				"cfsqltype" : "CF_SQL_VARCHAR",
+				"cfsqltype" : "CF_SQL_LONGVARCHAR",
 				"null" : ( arguments.data.exception.extendedInfo ?: "" ) == "",
 				"nulls" : ( arguments.data.exception.extendedInfo ?: "" ) == ""
 			},
@@ -68,7 +74,7 @@ component {
 						arguments.data.exception.stackTrace
 					)
 				),
-				"cfsqltype" : "CF_SQL_VARCHAR",
+				"cfsqltype" : "CF_SQL_LONGVARCHAR",
 				"null" : isNull( arguments.data.exception.stackTrace ) || (
 					isSimpleValue( arguments.data.exception.stackTrace ) && arguments.data.exception.stackTrace == ""
 				),
@@ -76,9 +82,14 @@ component {
 					isSimpleValue( arguments.data.exception.stackTrace ) && arguments.data.exception.stackTrace == ""
 				)
 			},
-			"exception" : isNull( arguments.data.exception ) ? javacast( "null", "" ) : serializeJSON(
-				arguments.data.exception
-			),
+			"exception" : {
+				"value" : isNull( arguments.data.exception ) ? javacast( "null", "" ) : serializeJSON(
+					arguments.data.exception
+				),
+				"cfsqltype" : "CF_SQL_LONGVARCHAR",
+				"null" : isNull( arguments.data.exception ),
+				"nulls" : isNull( arguments.data.exception )
+			},
 			"failedDate" : {
 				"value" : getCurrentUnixTimestamp(),
 				"cfsqltype" : "CF_SQL_BIGINT"

--- a/models/Jobs/Batch.cfc
+++ b/models/Jobs/Batch.cfc
@@ -10,6 +10,7 @@ component accessors="true" {
 	property name="totalJobs" type="numeric";
 	property name="pendingJobs" type="numeric";
 	property name="failedJobs" type="numeric";
+	property name="successfulJobs" type="numeric";
 	property name="failedJobIds" type="array";
 	property name="options" type="struct";
 	property name="createdDate" type="numeric";

--- a/models/Jobs/Batch.cfc
+++ b/models/Jobs/Batch.cfc
@@ -3,6 +3,7 @@ component accessors="true" {
 	property name="dispatcher" inject="provider:Dispatcher@cbq";
 	property name="cbq" inject="provider:@cbq";
 	property name="wirebox" inject="wirebox";
+	property name="log" inject="logbox:logger:{this}";
 	property name="repository";
 
 	property name="id" type="string";
@@ -50,7 +51,12 @@ component accessors="true" {
 		}
 
 		getRepository().markAsFinished( variables.id );
-		dispatchThenJobIfNeeded();
+
+		try {
+			dispatchThenJobIfNeeded();
+		} catch ( any e ) {
+			log.error( "Failed to dispatch then job for batch [#variables.id#]: #e.message#", e );
+		}
 
 		if ( counts.allJobsHaveRanExactlyOnce ) {
 			dispatchFinallyJobIfNeeded();
@@ -65,7 +71,11 @@ component accessors="true" {
 				cancel();
 			}
 
-			dispatchCatchJobIfNeeded( arguments.error );
+			try {
+				dispatchCatchJobIfNeeded( arguments.error );
+			} catch ( any e ) {
+				log.error( "Failed to dispatch catch job for batch [#variables.id#]: #e.message#", e );
+			}
 		}
 
 		if ( counts.allJobsHaveRanExactlyOnce ) {

--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -110,10 +110,7 @@ component singleton accessors="true" {
 			var updatedValues = {
 				"pendingJobs" : data.pendingJobs - 1,
 				"successfulJobs" : data.successfulJobs + 1,
-				"failedJobs" : data.failedJobs,
-				"failedJobIds" : serializeJSON(
-					deserializeJSON( data.failedJobIds ).filter( ( failedJobId ) => failedJobId != jobId )
-				)
+				"failedJobs" : data.failedJobs
 			};
 
 			qb.table( variables.batchTableName )

--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -58,12 +58,16 @@ component singleton accessors="true" {
 		var id = isNull( variables.timeBasedUUIDGenerator ) ? createUUID() : variables.timeBasedUUIDGenerator
 			.generate()
 			.toString();
+		local.batchName = arguments.batch.getName();
+		if ( isNull( local.batchName ) || !isSimpleValue( local.batchName ) ) {
+			local.batchName = "";
+		}
 
 		qb.table( variables.batchTableName )
 			.insert(
 				values = {
 					"id" : id,
-					"name" : arguments.batch.getName(),
+					"name" : local.batchName,
 					"totalJobs" : 0,
 					"pendingJobs" : 0,
 					"failedJobs" : 0,

--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -11,7 +11,11 @@ component singleton accessors="true" {
 	property name="batchTableName" default="cbq_batches";
 
 	public DBBatchRepository function init() {
-		variables.timeBasedUUIDGenerator = createObject( "java", "com.fasterxml.uuid.Generators" ).timeBasedGenerator();
+		try {
+			variables.timeBasedUUIDGenerator = createObject( "java", "com.fasterxml.uuid.Generators" ).timeBasedGenerator();
+		} catch ( any e ) {
+			variables.timeBasedUUIDGenerator = javacast( "null", "" );
+		}
 		variables.defaultQueryOptions = {};
 		return this;
 	}
@@ -51,7 +55,9 @@ component singleton accessors="true" {
 	}
 
 	public Batch function store( required PendingBatch batch ) {
-		var id = variables.timeBasedUUIDGenerator.generate().toString();
+		var id = isNull( variables.timeBasedUUIDGenerator ) ? createUUID() : variables.timeBasedUUIDGenerator
+			.generate()
+			.toString();
 
 		qb.table( variables.batchTableName )
 			.insert(
@@ -102,23 +108,29 @@ component singleton accessors="true" {
 				throw( type = "cbq.BatchNotFound", message = "No batch found for id [#arguments.batchId#]" );
 			}
 
+			var updatedValues = {
+				"pendingJobs" : data.pendingJobs - 1,
+				"failedJobs" : data.failedJobs,
+				"failedJobIds" : serializeJSON(
+					deserializeJSON( data.failedJobIds ).filter( ( failedJobId ) => failedJobId != jobId )
+				)
+			};
+
+			if ( data.keyExists( "successfulJobs" ) ) {
+				updatedValues[ "successfulJobs" ] = data.successfulJobs + 1;
+			}
+
 			qb.table( variables.batchTableName )
 				.where( "id", arguments.batchId )
 				.update(
-					values = {
-						"pendingJobs" : data.pendingJobs - 1,
-						"failedJobs" : data.failedJobs,
-						"failedJobIds" : serializeJSON(
-							deserializeJSON( data.failedJobIds ).filter( ( failedJobId ) => failedJobId != jobId )
-						)
-					},
+					values = updatedValues,
 					options = variables.defaultQueryOptions
 				);
 
 			return {
 				"pendingJobs" : data.pendingJobs - 1,
 				"failedJobs" : data.failedJobs,
-				"allJobsHaveRanExactlyOnce" : ( data.pendingJobs - 1 ) - data.failedJobs == 0
+				"allJobsHaveRanExactlyOnce" : ( data.pendingJobs - 1 ) == 0
 			};
 		}
 	}
@@ -135,21 +147,23 @@ component singleton accessors="true" {
 				throw( type = "cbq.BatchNotFound", message = "No batch found for id [#arguments.batchId#]" );
 			}
 
+			var updatedValues = {
+				"pendingJobs" : data.pendingJobs - 1,
+				"failedJobs" : data.failedJobs + 1,
+				"failedJobIds" : serializeJSON( deserializeJSON( data.failedJobIds ).append( arguments.jobId ) )
+			};
+
 			qb.table( variables.batchTableName )
 				.where( "id", arguments.batchId )
 				.update(
-					values = {
-						"pendingJobs" : data.pendingJobs,
-						"failedJobs" : data.failedJobs + 1,
-						"failedJobIds" : serializeJSON( deserializeJSON( data.failedJobIds ).append( arguments.jobId ) )
-					},
+					values = updatedValues,
 					options = variables.defaultQueryOptions
 				);
 
 			return {
-				"pendingJobs" : data.pendingJobs,
+				"pendingJobs" : data.pendingJobs - 1,
 				"failedJobs" : data.failedJobs + 1,
-				"allJobsHaveRanExactlyOnce" : data.pendingJobs - ( data.failedJobs + 1 ) == 0
+				"allJobsHaveRanExactlyOnce" : ( data.pendingJobs - 1 ) == 0
 			};
 		}
 	}
@@ -191,6 +205,7 @@ component singleton accessors="true" {
 		batch.setTotalJobs( data.totalJobs );
 		batch.setPendingJobs( data.pendingJobs );
 		batch.setFailedJobs( data.failedJobs );
+		batch.setSuccessfulJobs( data.keyExists( "successfulJobs" ) ? data.successfulJobs : 0 );
 		batch.setFailedJobIds( deserializeJSON( data.failedJobIds ) );
 		batch.setOptions( deserializeJSON( data.options ) );
 		batch.setCreatedDate( data.createdDate );

--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -64,6 +64,7 @@ component singleton accessors="true" {
 					"name" : batchName,
 					"totalJobs" : 0,
 					"pendingJobs" : 0,
+					"successfulJobs" : 0,
 					"failedJobs" : 0,
 					"failedJobIds" : "[]",
 					"options" : serializeJSON( arguments.batch.getOptions() ),
@@ -108,15 +109,12 @@ component singleton accessors="true" {
 
 			var updatedValues = {
 				"pendingJobs" : data.pendingJobs - 1,
+				"successfulJobs" : data.successfulJobs + 1,
 				"failedJobs" : data.failedJobs,
 				"failedJobIds" : serializeJSON(
 					deserializeJSON( data.failedJobIds ).filter( ( failedJobId ) => failedJobId != jobId )
 				)
 			};
-
-			if ( data.keyExists( "successfulJobs" ) ) {
-				updatedValues[ "successfulJobs" ] = data.successfulJobs + 1;
-			}
 
 			qb.table( variables.batchTableName )
 				.where( "id", arguments.batchId )
@@ -203,7 +201,7 @@ component singleton accessors="true" {
 		batch.setTotalJobs( data.totalJobs );
 		batch.setPendingJobs( data.pendingJobs );
 		batch.setFailedJobs( data.failedJobs );
-		batch.setSuccessfulJobs( data.keyExists( "successfulJobs" ) ? data.successfulJobs : 0 );
+		batch.setSuccessfulJobs( data.successfulJobs );
 		batch.setFailedJobIds( deserializeJSON( data.failedJobIds ) );
 		batch.setOptions( deserializeJSON( data.options ) );
 		batch.setCreatedDate( data.createdDate );

--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -11,11 +11,7 @@ component singleton accessors="true" {
 	property name="batchTableName" default="cbq_batches";
 
 	public DBBatchRepository function init() {
-		try {
-			variables.timeBasedUUIDGenerator = createObject( "java", "com.fasterxml.uuid.Generators" ).timeBasedGenerator();
-		} catch ( any e ) {
-			variables.timeBasedUUIDGenerator = javacast( "null", "" );
-		}
+		variables.timeBasedUUIDGenerator = createObject( "java", "com.fasterxml.uuid.Generators" ).timeBasedGenerator();
 		variables.defaultQueryOptions = {};
 		return this;
 	}
@@ -55,19 +51,17 @@ component singleton accessors="true" {
 	}
 
 	public Batch function store( required PendingBatch batch ) {
-		var id = isNull( variables.timeBasedUUIDGenerator ) ? createUUID() : variables.timeBasedUUIDGenerator
-			.generate()
-			.toString();
-		local.batchName = arguments.batch.getName();
-		if ( isNull( local.batchName ) || !isSimpleValue( local.batchName ) ) {
-			local.batchName = "";
+		var id = variables.timeBasedUUIDGenerator.generate().toString();
+		var batchName = arguments.batch.getName();
+		if ( isNull( batchName ) || !isSimpleValue( batchName ) ) {
+			batchName = "";
 		}
 
 		qb.table( variables.batchTableName )
 			.insert(
 				values = {
 					"id" : id,
-					"name" : local.batchName,
+					"name" : batchName,
 					"totalJobs" : 0,
 					"pendingJobs" : 0,
 					"failedJobs" : 0,

--- a/models/Jobs/DBBatchRepository.cfc
+++ b/models/Jobs/DBBatchRepository.cfc
@@ -118,10 +118,7 @@ component singleton accessors="true" {
 
 			qb.table( variables.batchTableName )
 				.where( "id", arguments.batchId )
-				.update(
-					values = updatedValues,
-					options = variables.defaultQueryOptions
-				);
+				.update( values = updatedValues, options = variables.defaultQueryOptions );
 
 			return {
 				"pendingJobs" : data.pendingJobs - 1,
@@ -151,10 +148,7 @@ component singleton accessors="true" {
 
 			qb.table( variables.batchTableName )
 				.where( "id", arguments.batchId )
-				.update(
-					values = updatedValues,
-					options = variables.defaultQueryOptions
-				);
+				.update( values = updatedValues, options = variables.defaultQueryOptions );
 
 			return {
 				"pendingJobs" : data.pendingJobs - 1,

--- a/models/Providers/AbstractQueueProvider.cfc
+++ b/models/Providers/AbstractQueueProvider.cfc
@@ -170,116 +170,130 @@ component accessors="true" {
 				}
 			} )
 			.onException( function( e ) {
-				// log failed job
-				if ( !isNull( e ) && "java.util.concurrent.CompletionException" == e.getClass().getName() ) {
-					var rootCause = e.getCause();
-					if ( !isNull( rootCause ) ) {
-						e = rootCause;
-					}
-				}
-
-				if ( log.canError() ) {
-					log.error(
-						"Exception when running job: #e.message#",
-						{
-							"job" : job.getMemento(),
-							"exception" : isNull( e ) ? javacast( "null", "" ) : e
+				try {
+					// log failed job
+					if ( !isNull( e ) && "java.util.concurrent.CompletionException" == e.getClass().getName() ) {
+						var rootCause = e.getCause();
+						if ( !isNull( rootCause ) ) {
+							e = rootCause;
 						}
-					);
-				}
-
-				afterJobException(
-					job.getId(),
-					job,
-					pool,
-					isNull( e ) ? javacast( "null", "" ) : e
-				);
-
-				variables.interceptorService.announce(
-					"onCBQJobException",
-					{
-						"job" : job,
-						"pool" : pool,
-						"exception" : isNull( e ) ? javacast( "null", "" ) : e
-					}
-				);
-
-				var jobMaxAttempts = getMaxAttemptsForJob( job, pool );
-				if ( job.getIsCancelled() ) {
-					if ( variables.log.canDebug() ) {
-						variables.log.debug( "Job [#job.getId()#] was cancelled. Reason: #job.getCancelledReason()#. Deleting job [#job.getId()#]." );
 					}
 
-					if ( structKeyExists( job, "onFailure" ) ) {
-						invoke(
-							job,
-							"onFailure",
-							{ "exception" : isNull( e ) ? javacast( "null", "" ) : e }
+					if ( log.canError() ) {
+						log.error(
+							"Exception when running job: #e.message#",
+							{
+								"job" : job.getMemento(),
+								"exception" : isNull( e ) ? javacast( "null", "" ) : e
+							}
 						);
 					}
 
-					variables.interceptorService.announce(
-						"onCBQJobFailed",
-						{
-							"job" : job,
-							"exception" : isNull( e ) ? javacast( "null", "" ) : e
-						}
-					);
-
-					afterJobFailed(
-						job.getId(),
-						job,
-						pool,
-						isNull( e ) ? javacast( "null", "" ) : e
-					);
-					ensureFailedBatchJobIsRecorded( job, isNull( e ) ? javacast( "null", "" ) : e );
-
-					variables.log.debug( "Marked job ###job.getId()# as failed after being cancelled." );
-				} else if ( jobMaxAttempts == 0 || job.getCurrentAttempt() < jobMaxAttempts ) {
-					if ( jobMaxAttempts == 0 && variables.log.canDebug() ) {
-						variables.log.debug( "Job ###job.getId()# has a maxAttempts of 0 and will always be released." );
-					}
-					if ( variables.log.canDebug() ) {
-						variables.log.debug( "Releasing job ###job.getId()#" );
-					}
-					releaseJob( job, pool );
-					if ( variables.log.canDebug() ) {
-						variables.log.debug( "Released job ###job.getId()#" );
-					}
-				} else {
-					if ( variables.log.canDebug() ) {
-						variables.log.debug( "Maximum attempts reached. Deleting job ###job.getId()#" );
-					}
-
-					if ( structKeyExists( job, "onFailure" ) ) {
-						invoke(
+					try {
+						afterJobException(
+							job.getId(),
 							job,
-							"onFailure",
-							{ "exception" : isNull( e ) ? javacast( "null", "" ) : e }
+							pool,
+							isNull( e ) ? javacast( "null", "" ) : e
+						);
+					} catch ( any sideEffectException ) {
+						logSideEffectFailure(
+							"afterJobException",
+							job,
+							sideEffectException
 						);
 					}
 
-					variables.interceptorService.announce(
-						"onCBQJobFailed",
-						{
-							"job" : job,
-							"exception" : isNull( e ) ? javacast( "null", "" ) : e
+					try {
+						variables.interceptorService.announce(
+							"onCBQJobException",
+							{
+								"job" : job,
+								"pool" : pool,
+								"exception" : isNull( e ) ? javacast( "null", "" ) : e
+							}
+						);
+					} catch ( any sideEffectException ) {
+						logSideEffectFailure(
+							"onCBQJobException",
+							job,
+							sideEffectException
+						);
+					}
+
+					var jobMaxAttempts = getMaxAttemptsForJob( job, pool );
+					if ( job.getIsCancelled() ) {
+						if ( variables.log.canDebug() ) {
+							variables.log.debug( "Job [#job.getId()#] was cancelled. Reason: #job.getCancelledReason()#. Deleting job [#job.getId()#]." );
 						}
-					);
-
-					afterJobFailed(
-						job.getId(),
-						job,
-						pool,
-						isNull( e ) ? javacast( "null", "" ) : e
-					);
-					ensureFailedBatchJobIsRecorded( job, isNull( e ) ? javacast( "null", "" ) : e );
-
-					variables.log.debug( "Marked job ###job.getId()# as failed after maximum failed attempts." );
+						markJobFailed(
+							job,
+							pool,
+							isNull( e ) ? javacast( "null", "" ) : e
+						);
+						variables.log.debug( "Marked job ###job.getId()# as failed after being cancelled." );
+					} else if ( jobMaxAttempts == 0 || job.getCurrentAttempt() < jobMaxAttempts ) {
+						if ( jobMaxAttempts == 0 && variables.log.canDebug() ) {
+							variables.log.debug( "Job ###job.getId()# has a maxAttempts of 0 and will always be released." );
+						}
+						if ( variables.log.canDebug() ) {
+							variables.log.debug( "Releasing job ###job.getId()#" );
+						}
+						try {
+							releaseJob( job, pool );
+							if ( variables.log.canDebug() ) {
+								variables.log.debug( "Released job ###job.getId()#" );
+							}
+						} catch ( any releaseException ) {
+							log.error(
+								"releaseJob failed for job ###job.getId()#. Falling back to terminal failure to prevent timeout-based re-pickup.",
+								{
+									"job" : job.getMemento(),
+									"originalException" : isNull( e ) ? javacast( "null", "" ) : e,
+									"releaseException" : releaseException
+								}
+							);
+							markJobFailed(
+								job,
+								pool,
+								isNull( e ) ? javacast( "null", "" ) : e
+							);
+						}
+					} else {
+						if ( variables.log.canDebug() ) {
+							variables.log.debug( "Maximum attempts reached. Deleting job ###job.getId()#" );
+						}
+						markJobFailed(
+							job,
+							pool,
+							isNull( e ) ? javacast( "null", "" ) : e
+						);
+						variables.log.debug( "Marked job ###job.getId()# as failed after maximum failed attempts." );
+					}
+				} catch ( any outerException ) {
+					try {
+						log.error(
+							"Critical: .onException handler failed for job ###job.getId()#. Forcing terminal failure.",
+							{
+								"job" : job.getMemento(),
+								"originalException" : isNull( e ) ? javacast( "null", "" ) : e,
+								"handlerException" : outerException
+							}
+						);
+					} catch ( any ignored ) {
+					}
+					try {
+						forceFailJob( job.getId(), pool );
+					} catch ( any ignored ) {
+					}
 				}
 
 				if ( !isNull( afterJobHook ) && ( isCustomFunction( afterJobHook ) || isClosure( afterJobHook ) ) ) {
-					afterJobHook( job, pool );
+					try {
+						afterJobHook( job, pool );
+					} catch ( any hookException ) {
+						logSideEffectFailure( "afterJobHook", job, hookException );
+					}
 				}
 			} );
 	}
@@ -308,6 +322,104 @@ component accessors="true" {
 		any exception
 	) {
 		return;
+	}
+
+	/**
+	 * Last-resort terminal failure for a job. Providers should override this with
+	 * a minimal, bulletproof write that takes the job out of any retry loop, even
+	 * when the normal afterJobFailed path has already failed. Skips bookkeeping
+	 * (onFailure hook, interceptors, batch recording) by design — it only runs
+	 * when those paths themselves are broken.
+	 */
+	public void function forceFailJob( required any id, WorkerPool pool ) {
+		return;
+	}
+
+	private void function markJobFailed(
+		required AbstractJob job,
+		required WorkerPool pool,
+		any exception
+	) {
+		if ( structKeyExists( arguments.job, "onFailure" ) ) {
+			try {
+				invoke(
+					arguments.job,
+					"onFailure",
+					{ "exception" : isNull( arguments.exception ) ? javacast( "null", "" ) : arguments.exception }
+				);
+			} catch ( any sideEffectException ) {
+				logSideEffectFailure(
+					"onFailure",
+					arguments.job,
+					sideEffectException
+				);
+			}
+		}
+
+		try {
+			variables.interceptorService.announce(
+				"onCBQJobFailed",
+				{
+					"job" : arguments.job,
+					"exception" : isNull( arguments.exception ) ? javacast( "null", "" ) : arguments.exception
+				}
+			);
+		} catch ( any sideEffectException ) {
+			logSideEffectFailure(
+				"onCBQJobFailed",
+				arguments.job,
+				sideEffectException
+			);
+		}
+
+		try {
+			afterJobFailed(
+				arguments.job.getId(),
+				arguments.job,
+				arguments.pool,
+				isNull( arguments.exception ) ? javacast( "null", "" ) : arguments.exception
+			);
+		} catch ( any sideEffectException ) {
+			logSideEffectFailure(
+				"afterJobFailed",
+				arguments.job,
+				sideEffectException
+			);
+			// afterJobFailed is what writes failedDate in DBProvider; if it threw, fall back.
+			try {
+				forceFailJob( arguments.job.getId(), arguments.pool );
+			} catch ( any ignored ) {
+			}
+		}
+
+		try {
+			ensureFailedBatchJobIsRecorded(
+				arguments.job,
+				isNull( arguments.exception ) ? javacast( "null", "" ) : arguments.exception
+			);
+		} catch ( any sideEffectException ) {
+			logSideEffectFailure(
+				"ensureFailedBatchJobIsRecorded",
+				arguments.job,
+				sideEffectException
+			);
+		}
+	}
+
+	private void function logSideEffectFailure(
+		required string stage,
+		required AbstractJob job,
+		required any exception
+	) {
+		try {
+			if ( log.canError() ) {
+				log.error(
+					"Side effect [#arguments.stage#] threw for job ###arguments.job.getId()#: #arguments.exception.message#",
+					{ "exception" : arguments.exception }
+				);
+			}
+		} catch ( any ignored ) {
+		}
 	}
 
 	public void function releaseJob( required AbstractJob job, required WorkerPool pool ) {

--- a/models/Providers/AbstractQueueProvider.cfc
+++ b/models/Providers/AbstractQueueProvider.cfc
@@ -245,14 +245,17 @@ component accessors="true" {
 								variables.log.debug( "Released job ###job.getId()#" );
 							}
 						} catch ( any releaseException ) {
-							log.error(
-								"releaseJob failed for job ###job.getId()#. Falling back to terminal failure to prevent timeout-based re-pickup.",
-								{
-									"job" : job.getMemento(),
-									"originalException" : isNull( e ) ? javacast( "null", "" ) : e,
-									"releaseException" : releaseException
-								}
-							);
+							try {
+								log.error(
+									"releaseJob failed for job ###job.getId()#. Falling back to terminal failure to prevent timeout-based re-pickup.",
+									{
+										"job" : job.getMemento(),
+										"originalException" : isNull( e ) ? javacast( "null", "" ) : e,
+										"releaseException" : releaseException
+									}
+								);
+							} catch ( any ignored ) {
+							}
 							markJobFailed(
 								job,
 								pool,

--- a/models/Providers/AbstractQueueProvider.cfc
+++ b/models/Providers/AbstractQueueProvider.cfc
@@ -166,7 +166,15 @@ component accessors="true" {
 				dispatchNextJobInChain( job, pool );
 
 				if ( !isNull( afterJobHook ) && ( isCustomFunction( afterJobHook ) || isClosure( afterJobHook ) ) ) {
-					afterJobHook( job, pool );
+					try {
+						afterJobHook( job, pool );
+					} catch ( any sideEffectException ) {
+						logSideEffectFailure(
+							"afterJobHook",
+							job,
+							sideEffectException
+						);
+					}
 				}
 			} )
 			.onException( function( e ) {

--- a/models/Providers/ColdBoxAsyncProvider.cfc
+++ b/models/Providers/ColdBoxAsyncProvider.cfc
@@ -25,7 +25,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 			}, workerPool.getExecutor() )
 			.thenCompose( function() {
 				job.setId( createUUID() );
-				if ( !isNull( arguments.currentAttempt ) ) {
+				if ( attempts > 0 ) {
 					job.setCurrentAttempt( attempts );
 				}
 				return marshalJob( job, workerPool );

--- a/models/Providers/ColdBoxAsyncProvider.cfc
+++ b/models/Providers/ColdBoxAsyncProvider.cfc
@@ -23,7 +23,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 				sleep( delay * 1000 );
 				return true;
 			}, workerPool.getExecutor() )
-			.then( function() {
+			.thenCompose( function() {
 				job.setId( createUUID() );
 				if ( !isNull( arguments.currentAttempt ) ) {
 					job.setCurrentAttempt( attempts );

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -394,11 +394,11 @@ component accessors="true" extends="AbstractQueueProvider" {
 							variables.getCurrentUnixTimestamp()
 						);
 				} );
-				// past the reserved date
+				// past the job's own timeout (availableDate was set to now + jobTimeout at reservation time)
 				q1.orWhere(
-					"reservedDate",
+					"availableDate",
 					"<=",
-					variables.getCurrentUnixTimestamp() - pool.getTimeout()
+					variables.getCurrentUnixTimestamp()
 				);
 				// reserved by a worker but never released
 				q1.orWhere( ( q3 ) => {
@@ -449,9 +449,9 @@ component accessors="true" extends="AbstractQueueProvider" {
 						q2.whereNull( "reservedDate" );
 					} )
 					.orWhere(
-						"reservedDate",
+						"availableDate",
 						"<=",
-						variables.getCurrentUnixTimestamp() - pool.getTimeout()
+						variables.getCurrentUnixTimestamp()
 					);
 			} )
 			.update(

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -340,6 +340,28 @@ component accessors="true" extends="AbstractQueueProvider" {
 			.update( values = { "completedDate" : getCurrentUnixTimestamp() }, options = variables.defaultQueryOptions );
 	}
 
+	public void function forceFailJob( required any id, WorkerPool pool ) {
+		newQuery()
+			.table( variables.tableName )
+			.where( "id", arguments.id )
+			.update(
+				values = {
+					"failedDate" : getCurrentUnixTimestamp(),
+					"reservedBy" : {
+						"value" : "",
+						"null" : true,
+						"nulls" : true
+					},
+					"reservedDate" : {
+						"value" : "",
+						"null" : true,
+						"nulls" : true
+					}
+				},
+				options = variables.defaultQueryOptions
+			);
+	}
+
 	private void function markJobAsFailedById( required numeric id, WorkerPool pool ) {
 		newQuery()
 			.table( variables.tableName )

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -395,11 +395,14 @@ component accessors="true" extends="AbstractQueueProvider" {
 						);
 				} );
 				// past the job's own timeout (availableDate was set to now + jobTimeout at reservation time)
-				q1.orWhere(
-					"availableDate",
-					"<=",
-					variables.getCurrentUnixTimestamp()
-				);
+				q1.orWhere( ( q2 ) => {
+					q2.whereNotNull( "reservedDate" )
+						.where(
+							"availableDate",
+							"<=",
+							variables.getCurrentUnixTimestamp()
+						);
+				} );
 				// reserved by a worker but never released
 				q1.orWhere( ( q3 ) => {
 					q3.whereNull( "reservedDate" )
@@ -448,11 +451,14 @@ component accessors="true" extends="AbstractQueueProvider" {
 						q2.whereNull( "reservedBy" );
 						q2.whereNull( "reservedDate" );
 					} )
-					.orWhere(
-						"availableDate",
-						"<=",
-						variables.getCurrentUnixTimestamp()
-					);
+					.orWhere( ( q2 ) => {
+						q2.whereNotNull( "reservedDate" )
+							.where(
+								"availableDate",
+								"<=",
+								variables.getCurrentUnixTimestamp()
+							);
+					} );
 			} )
 			.update(
 				values = {

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -58,35 +58,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 				var lockedRecords = fetchLockedRecords( capacity, pool );
 
 				for ( var job in lockedRecords ) {
-					var jobCFC = variables.deserializeJob( job.payload, job.id, job.attempts );
-
-					var jobMaxAttempts = getMaxAttemptsForJob( jobCFC, pool );
-					if ( jobMaxAttempts != 0 && job.attempts >= jobMaxAttempts ) {
-						if ( log.canWarn() ) {
-							log.warn(
-								"Job ###jobCFC.getId()# already has #job.attempts# attempts (max #jobMaxAttempts#). Marking as failed without further retry.",
-								{ "job" : jobCFC.getMemento() }
-							);
-						}
-						markJobAsFailedById( job.id, pool );
-						ensureFailedBatchJobIsRecorded(
-							jobCFC,
-							"Job exceeded maximum attempts (#jobMaxAttempts#) before execution."
-						);
-						continue;
-					}
-
-					incrementJobAttempts( jobCFC, pool );
-					application.cbController.getModuleService().loadMappings();
-					variables.marshalJob(
-						job = jobCFC,
-						pool = pool,
-						afterJobHook = () => {
-							// variables.log.debug( "Job finished. Immediately running the scheduled task again." );
-							// forceRun = true;
-							// task.run();
-						}
-					);
+					processLockedRecord( job, pool );
 				}
 
 				return lockedRecords.len();
@@ -290,6 +262,39 @@ component accessors="true" extends="AbstractQueueProvider" {
 
 	public boolean function supportsMultipleQueues() {
 		return true;
+	}
+
+	private void function processLockedRecord( required any record, required WorkerPool pool ) {
+		var jobCFC = variables.deserializeJob(
+			arguments.record.payload,
+			arguments.record.id,
+			arguments.record.attempts
+		);
+
+		var jobMaxAttempts = getMaxAttemptsForJob( jobCFC, arguments.pool );
+		if ( jobMaxAttempts != 0 && arguments.record.attempts >= jobMaxAttempts ) {
+			if ( log.canWarn() ) {
+				log.warn(
+					"Job ###jobCFC.getId()# already has #arguments.record.attempts# attempts (max #jobMaxAttempts#). Marking as failed without further retry.",
+					{ "job" : jobCFC.getMemento() }
+				);
+			}
+			markJobAsFailedById( arguments.record.id, arguments.pool );
+			ensureFailedBatchJobIsRecorded(
+				jobCFC,
+				"Job exceeded maximum attempts (#jobMaxAttempts#) before execution."
+			);
+			return;
+		}
+
+		incrementJobAttempts( jobCFC, arguments.pool );
+		application.cbController.getModuleService().loadMappings();
+		variables.marshalJob(
+			job = jobCFC,
+			pool = arguments.pool,
+			afterJobHook = () => {
+			}
+		);
 	}
 
 	private void function incrementJobAttempts( required AbstractJob job, required WorkerPool pool ) {

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -377,7 +377,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 		var ids = newQuery()
 			.from( variables.tableName )
 			.limit( arguments.capacity )
-			.lockForUpdate( skipLocked = true )
+			.lockForUpdate()
 			.when( !shouldWorkAllQueues( arguments.pool ), ( q ) => q.whereIn( "queue", pool.getQueue() ) )
 			.where( ( q ) => {
 				q.whereNull( "completedDate" );

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -59,6 +59,23 @@ component accessors="true" extends="AbstractQueueProvider" {
 
 				for ( var job in lockedRecords ) {
 					var jobCFC = variables.deserializeJob( job.payload, job.id, job.attempts );
+
+					var jobMaxAttempts = getMaxAttemptsForJob( jobCFC, pool );
+					if ( jobMaxAttempts != 0 && job.attempts >= jobMaxAttempts ) {
+						if ( log.canWarn() ) {
+							log.warn(
+								"Job ###jobCFC.getId()# already has #job.attempts# attempts (max #jobMaxAttempts#). Marking as failed without further retry.",
+								{ "job" : jobCFC.getMemento() }
+							);
+						}
+						markJobAsFailedById( job.id, pool );
+						ensureFailedBatchJobIsRecorded(
+							jobCFC,
+							"Job exceeded maximum attempts (#jobMaxAttempts#) before execution."
+						);
+						continue;
+					}
+
 					incrementJobAttempts( jobCFC, pool );
 					application.cbController.getModuleService().loadMappings();
 					variables.marshalJob(

--- a/models/Providers/DBProvider.cfc
+++ b/models/Providers/DBProvider.cfc
@@ -377,7 +377,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 		var ids = newQuery()
 			.from( variables.tableName )
 			.limit( arguments.capacity )
-			.lockForUpdate()
+			.lockForUpdate( skipLocked = true )
 			.when( !shouldWorkAllQueues( arguments.pool ), ( q ) => q.whereIn( "queue", pool.getQueue() ) )
 			.where( ( q ) => {
 				q.whereNull( "completedDate" );

--- a/models/Providers/SyncProvider.cfc
+++ b/models/Providers/SyncProvider.cfc
@@ -139,7 +139,7 @@ component accessors="true" extends="AbstractQueueProvider" {
 					invoke(
 						job,
 						"onFailure",
-						{ "excpetion" : e }
+						{ "exception" : e }
 					);
 				}
 

--- a/resources/database/migrations/2000_01_01_000008_add_successfulJobs_to_cbq_batches_table.cfc
+++ b/resources/database/migrations/2000_01_01_000008_add_successfulJobs_to_cbq_batches_table.cfc
@@ -2,7 +2,7 @@ component {
 
 	function up( schema ) {
 		schema.alter( "cbq_batches", ( t ) => {
-			t.unsignedInteger( "successfulJobs" ).default( 0 );
+			t.addColumn( t.unsignedInteger( "successfulJobs" ).default( 0 ) );
 		} );
 	}
 

--- a/resources/database/migrations/2000_01_01_000008_add_successfulJobs_to_cbq_batches_table.cfc
+++ b/resources/database/migrations/2000_01_01_000008_add_successfulJobs_to_cbq_batches_table.cfc
@@ -1,0 +1,15 @@
+component {
+
+	function up( schema ) {
+		schema.alter( "cbq_batches", ( t ) => {
+			t.unsignedInteger( "successfulJobs" ).default( 0 );
+		} );
+	}
+
+	function down( schema ) {
+		schema.alter( "cbq_batches", ( t ) => {
+			t.dropColumn( "successfulJobs" );
+		} );
+	}
+
+}

--- a/resources/database/migrations/2000_01_01_000009_make_cbq_batches_name_nullable.cfc
+++ b/resources/database/migrations/2000_01_01_000009_make_cbq_batches_name_nullable.cfc
@@ -1,0 +1,15 @@
+component {
+
+	function up( schema, qb ) {
+		schema.alter( "cbq_batches", ( t ) => {
+			t.modifyColumn( "name", t.string( "name" ).nullable() );
+		} );
+	}
+
+	function down( schema, qb ) {
+		schema.alter( "cbq_batches", ( t ) => {
+			t.modifyColumn( "name", t.string( "name" ) );
+		} );
+	}
+
+}

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -21,6 +21,10 @@ component {
     this.mappings[ "/testbox" ] = rootPath & "/testbox";
 
     this.datasource = "cbq";
+	this.javaSettings = {
+		"loadPaths" : [ rootPath & "/lib" ],
+		"reloadOnChange" : false
+	};
 
     function onRequestStart() {
         createObject( "java", "java.lang.System" ).setProperty( "ENVIRONMENT", "testing" );

--- a/tests/resources/app/models/Jobs/AlwaysErrorJob.cfc
+++ b/tests/resources/app/models/Jobs/AlwaysErrorJob.cfc
@@ -1,0 +1,10 @@
+component extends="cbq.models.Jobs.AbstractJob" {
+
+	function handle() {
+		throw(
+			type = "cbq.tests.AlwaysErrorJob",
+			message = "This job always errors for testing."
+		);
+	}
+
+}

--- a/tests/resources/app/models/Jobs/AlwaysErrorJob.cfc
+++ b/tests/resources/app/models/Jobs/AlwaysErrorJob.cfc
@@ -1,10 +1,7 @@
 component extends="cbq.models.Jobs.AbstractJob" {
 
 	function handle() {
-		throw(
-			type = "cbq.tests.AlwaysErrorJob",
-			message = "This job always errors for testing."
-		);
+		throw( type = "cbq.tests.AlwaysErrorJob", message = "This job always errors for testing." );
 	}
 
 }

--- a/tests/resources/app/models/Jobs/BeforeAndAfterJob.cfc
+++ b/tests/resources/app/models/Jobs/BeforeAndAfterJob.cfc
@@ -1,15 +1,15 @@
 component extends="cbq.models.Jobs.AbstractJob" {
 
-    function handle() {
-        // do nothing
-    }
+	function handle() {
+		// do nothing
+	}
 
-    function before() {
-        application.jobBeforeCalled = true;
-    }
+	function before() {
+		application.jobBeforeCalled = true;
+	}
 
-    function after() {
-        application.jobAfterCalled = true;
-    }
+	function after() {
+		application.jobAfterCalled = true;
+	}
 
 }

--- a/tests/resources/app/models/Jobs/OnFailureCapturingJob.cfc
+++ b/tests/resources/app/models/Jobs/OnFailureCapturingJob.cfc
@@ -2,13 +2,13 @@ component extends="cbq.models.Jobs.AbstractJob" {
 
 	function handle() {
 		throw(
-			type    = "cbq.tests.OnFailureCapturingJob",
+			type = "cbq.tests.OnFailureCapturingJob",
 			message = "This job always errors to test the onFailure exception argument."
 		);
 	}
 
 	function onFailure() {
-		application.onFailureExceptionReceived   = !isNull( arguments.exception );
+		application.onFailureExceptionReceived = !isNull( arguments.exception );
 		application.onFailureExceptionIsExpcetion = structKeyExists( arguments, "excpetion" );
 	}
 

--- a/tests/resources/app/models/Jobs/OnFailureCapturingJob.cfc
+++ b/tests/resources/app/models/Jobs/OnFailureCapturingJob.cfc
@@ -9,7 +9,7 @@ component extends="cbq.models.Jobs.AbstractJob" {
 
 	function onFailure() {
 		application.onFailureExceptionReceived = !isNull( arguments.exception );
-		application.onFailureExceptionIsExpcetion = structKeyExists( arguments, "excpetion" );
+		application.onFailureExceptionHasExcpetionKey = structKeyExists( arguments, "excpetion" );
 	}
 
 }

--- a/tests/resources/app/models/Jobs/OnFailureCapturingJob.cfc
+++ b/tests/resources/app/models/Jobs/OnFailureCapturingJob.cfc
@@ -1,0 +1,15 @@
+component extends="cbq.models.Jobs.AbstractJob" {
+
+	function handle() {
+		throw(
+			type    = "cbq.tests.OnFailureCapturingJob",
+			message = "This job always errors to test the onFailure exception argument."
+		);
+	}
+
+	function onFailure() {
+		application.onFailureExceptionReceived   = !isNull( arguments.exception );
+		application.onFailureExceptionIsExpcetion = structKeyExists( arguments, "excpetion" );
+	}
+
+}

--- a/tests/resources/app/models/Jobs/ReleaseTestJob.cfc
+++ b/tests/resources/app/models/Jobs/ReleaseTestJob.cfc
@@ -1,11 +1,11 @@
 component extends="cbq.models.Jobs.AbstractJob" {
 
-    function handle() {
-        this.release( 2 );
-    }
+	function handle() {
+		this.release( 2 );
+	}
 
-    function onFailure() {
-        this.onFailureCalled = true;
-    }
+	function onFailure() {
+		this.onFailureCalled = true;
+	}
 
 }

--- a/tests/resources/app/models/Jobs/RequestScopeBeforeAndAfterJob.cfc
+++ b/tests/resources/app/models/Jobs/RequestScopeBeforeAndAfterJob.cfc
@@ -1,0 +1,15 @@
+component extends="cbq.models.Jobs.AbstractJob" {
+
+	function handle() {
+		// do nothing
+	}
+
+	function before() {
+		request.jobBeforeCalled = true;
+	}
+
+	function after() {
+		request.jobAfterCalled = true;
+	}
+
+}

--- a/tests/resources/app/models/Jobs/SendWelcomeEmailJob.cfc
+++ b/tests/resources/app/models/Jobs/SendWelcomeEmailJob.cfc
@@ -1,9 +1,9 @@
 component extends="cbq.models.Jobs.AbstractJob" {
 
-    property name="log" inject="logbox:logger:{this}";
+	property name="log" inject="logbox:logger:{this}";
 
-    function handle() {
-        log.info( "sending email" );
-    }
+	function handle() {
+		log.info( "sending email" );
+	}
 
 }

--- a/tests/resources/app/models/Providers/FailingReleaseDBProvider.cfc
+++ b/tests/resources/app/models/Providers/FailingReleaseDBProvider.cfc
@@ -1,0 +1,17 @@
+/**
+ * Test fixture: a DBProvider whose releaseJob always throws.
+ * Used by DBProviderMaxAttemptsSpec to verify that the catch block
+ * in marshalJob's .onException handler correctly falls back to
+ * markJobFailed when releaseJob fails — without needing MockBox
+ * (which interferes with WireBox provider methods in async threads).
+ */
+component extends="cbq.models.Providers.DBProvider" {
+
+	public void function releaseJob( required any job, required any pool ) {
+		throw(
+			type    = "FailingReleaseDBProvider.SimulatedFailure",
+			message = "Simulated releaseJob failure for testing"
+		);
+	}
+
+}

--- a/tests/resources/app/models/Providers/FailingReleaseDBProvider.cfc
+++ b/tests/resources/app/models/Providers/FailingReleaseDBProvider.cfc
@@ -9,7 +9,7 @@ component extends="cbq.models.Providers.DBProvider" {
 
 	public void function releaseJob( required any job, required any pool ) {
 		throw(
-			type    = "FailingReleaseDBProvider.SimulatedFailure",
+			type = "FailingReleaseDBProvider.SimulatedFailure",
 			message = "Simulated releaseJob failure for testing"
 		);
 	}

--- a/tests/specs/integration/BatchFinallySpec.cfc
+++ b/tests/specs/integration/BatchFinallySpec.cfc
@@ -27,7 +27,6 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 						job = "BeforeAndAfterJob",
 						connection = "syncBatch"
 					);
-				pendingBatch.setName( "sync-failing-finally" );
 
 				try {
 					pendingBatch.dispatch();
@@ -50,7 +49,6 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 						job = "BeforeAndAfterJob",
 						connection = "syncBatch"
 					);
-				pendingBatch.setName( "sync-success-finally" );
 
 				pendingBatch.dispatch();
 

--- a/tests/specs/integration/BatchFinallySpec.cfc
+++ b/tests/specs/integration/BatchFinallySpec.cfc
@@ -27,15 +27,35 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 						job = "BeforeAndAfterJob",
 						connection = "syncBatch"
 					);
+				pendingBatch.setName( "sync-failing-finally" );
 
 				try {
 					pendingBatch.dispatch();
-				} catch ( any e ) {
+				} catch ( cbq.MaxAttemptsReached e ) {
 					// The sync provider rethrows the terminal failure.
 				}
 
 				expect( application.jobAfterCalled )
 					.toBeTrue( "The `finally` job should dispatch even when the last job fails." );
+			} );
+
+			it( "dispatches the finally job when all jobs succeed", function() {
+				var cbq = getWireBox().getInstance( "@cbq" );
+				registerSyncConnectionAndWorkerPool();
+
+				var pendingBatch = cbq
+					.batch( [ cbq.job( "SendWelcomeEmailJob" ), cbq.job( "SendWelcomeEmailJob" ) ] )
+					.onConnection( "syncBatch" )
+					.onComplete(
+						job = "BeforeAndAfterJob",
+						connection = "syncBatch"
+					);
+				pendingBatch.setName( "sync-success-finally" );
+
+				pendingBatch.dispatch();
+
+				expect( application.jobAfterCalled )
+					.toBeTrue( "The `finally` job should dispatch when all batch jobs succeed." );
 			} );
 		} );
 	}

--- a/tests/specs/integration/BatchFinallySpec.cfc
+++ b/tests/specs/integration/BatchFinallySpec.cfc
@@ -1,0 +1,62 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function run() {
+		describe( "batch finally dispatching", function() {
+			beforeEach( function() {
+				structDelete( application, "jobBeforeCalled" );
+				structDelete( application, "jobAfterCalled" );
+
+				param application.jobBeforeCalled = false;
+				param application.jobAfterCalled = false;
+			} );
+
+			it( "dispatches the finally job when the last job fails", function() {
+				var cbq = getWireBox().getInstance( "@cbq" );
+				registerSyncConnectionAndWorkerPool();
+
+				var successJob = cbq.job( "SendWelcomeEmailJob" );
+				var failingJob = cbq.job(
+					job = "ReleaseTestJob",
+					maxAttempts = 1
+				);
+
+				var pendingBatch = cbq
+					.batch( [ successJob, failingJob ] )
+					.onConnection( "syncBatch" )
+					.onComplete(
+						job = "BeforeAndAfterJob",
+						connection = "syncBatch"
+					);
+
+				try {
+					pendingBatch.dispatch();
+				} catch ( any e ) {
+					// The sync provider rethrows the terminal failure.
+				}
+
+				expect( application.jobAfterCalled )
+					.toBeTrue( "The `finally` job should dispatch even when the last job fails." );
+			} );
+		} );
+	}
+
+	private void function registerSyncConnectionAndWorkerPool() {
+		var config = getWireBox().getInstance( "Config@cbq" );
+
+		if ( !config.getConnections().keyExists( "syncBatch" ) ) {
+			config.registerConnection(
+				name = "syncBatch",
+				provider = getWireBox().getInstance( "SyncProvider@cbq" ).setProperties( {} )
+			);
+		}
+
+		if ( !config.getWorkerPools().keyExists( "syncBatch" ) ) {
+			config.registerWorkerPool(
+				name = "syncBatch",
+				connectionName = "syncBatch",
+				maxAttempts = 1
+			);
+		}
+	}
+
+}

--- a/tests/specs/integration/BatchFinallySpec.cfc
+++ b/tests/specs/integration/BatchFinallySpec.cfc
@@ -15,18 +15,12 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				registerSyncConnectionAndWorkerPool();
 
 				var successJob = cbq.job( "SendWelcomeEmailJob" );
-				var failingJob = cbq.job(
-					job = "ReleaseTestJob",
-					maxAttempts = 1
-				);
+				var failingJob = cbq.job( job = "ReleaseTestJob", maxAttempts = 1 );
 
 				var pendingBatch = cbq
 					.batch( [ successJob, failingJob ] )
 					.onConnection( "syncBatch" )
-					.onComplete(
-						job = "RequestScopeBeforeAndAfterJob",
-						connection = "syncBatch"
-					);
+					.onComplete( job = "RequestScopeBeforeAndAfterJob", connection = "syncBatch" );
 
 				try {
 					pendingBatch.dispatch();
@@ -34,8 +28,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					// The sync provider rethrows the terminal failure.
 				}
 
-				expect( request.jobAfterCalled )
-					.toBeTrue( "The `finally` job should dispatch even when the last job fails." );
+				expect( request.jobAfterCalled ).toBeTrue( "The `finally` job should dispatch even when the last job fails." );
 			} );
 
 			it( "dispatches the finally job when all jobs succeed", function() {
@@ -43,17 +36,16 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				registerSyncConnectionAndWorkerPool();
 
 				var pendingBatch = cbq
-					.batch( [ cbq.job( "SendWelcomeEmailJob" ), cbq.job( "SendWelcomeEmailJob" ) ] )
+					.batch( [
+						cbq.job( "SendWelcomeEmailJob" ),
+						cbq.job( "SendWelcomeEmailJob" )
+					] )
 					.onConnection( "syncBatch" )
-					.onComplete(
-						job = "RequestScopeBeforeAndAfterJob",
-						connection = "syncBatch"
-					);
+					.onComplete( job = "RequestScopeBeforeAndAfterJob", connection = "syncBatch" );
 
 				pendingBatch.dispatch();
 
-				expect( request.jobAfterCalled )
-					.toBeTrue( "The `finally` job should dispatch when all batch jobs succeed." );
+				expect( request.jobAfterCalled ).toBeTrue( "The `finally` job should dispatch when all batch jobs succeed." );
 			} );
 		} );
 	}

--- a/tests/specs/integration/BatchFinallySpec.cfc
+++ b/tests/specs/integration/BatchFinallySpec.cfc
@@ -3,11 +3,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 	function run() {
 		describe( "batch finally dispatching", function() {
 			beforeEach( function() {
-				structDelete( application, "jobBeforeCalled" );
-				structDelete( application, "jobAfterCalled" );
+				structDelete( request, "jobBeforeCalled" );
+				structDelete( request, "jobAfterCalled" );
 
-				param application.jobBeforeCalled = false;
-				param application.jobAfterCalled = false;
+				param request.jobBeforeCalled = false;
+				param request.jobAfterCalled = false;
 			} );
 
 			it( "dispatches the finally job when the last job fails", function() {
@@ -24,7 +24,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					.batch( [ successJob, failingJob ] )
 					.onConnection( "syncBatch" )
 					.onComplete(
-						job = "BeforeAndAfterJob",
+						job = "RequestScopeBeforeAndAfterJob",
 						connection = "syncBatch"
 					);
 
@@ -34,7 +34,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					// The sync provider rethrows the terminal failure.
 				}
 
-				expect( application.jobAfterCalled )
+				expect( request.jobAfterCalled )
 					.toBeTrue( "The `finally` job should dispatch even when the last job fails." );
 			} );
 
@@ -46,13 +46,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					.batch( [ cbq.job( "SendWelcomeEmailJob" ), cbq.job( "SendWelcomeEmailJob" ) ] )
 					.onConnection( "syncBatch" )
 					.onComplete(
-						job = "BeforeAndAfterJob",
+						job = "RequestScopeBeforeAndAfterJob",
 						connection = "syncBatch"
 					);
 
 				pendingBatch.dispatch();
 
-				expect( application.jobAfterCalled )
+				expect( request.jobAfterCalled )
 					.toBeTrue( "The `finally` job should dispatch when all batch jobs succeed." );
 			} );
 		} );

--- a/tests/specs/integration/DBBatchRepositoryCountsSpec.cfc
+++ b/tests/specs/integration/DBBatchRepositoryCountsSpec.cfc
@@ -1,0 +1,124 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function run() {
+		describe( "DBBatchRepository counts", function() {
+			it( "initializes successfulJobs for newly stored batches", function() {
+				var repository = getWireBox().getInstance( "DBBatchRepository@cbq" );
+				var batch = repository.store(
+					getWireBox()
+						.getInstance( "@cbq" )
+						.batch( [] )
+						.allowFailures()
+				);
+
+				expect( batch.getSuccessfulJobs() ).toBe( 0 );
+			} );
+
+			it( "successful jobs increment successfulJobs and decrement pendingJobs", function() {
+				var repository = getWireBox().getInstance( "DBBatchRepository@cbq" );
+				var config = registerSyncConnectionAndWorkerPool();
+				var batch = createTrackedBatch( repository, 1 );
+				var provider = config.getConnection( "syncBatchCounts" ).getProvider();
+				var pool = config.getWorkerPool( "syncBatchCounts" );
+
+				var job = getWireBox()
+					.getInstance( "@cbq" )
+					.job( "SendWelcomeEmailJob" )
+					.setId( createUUID() )
+					.withBatchId( batch.getId() );
+
+				provider.marshalJob( job, pool );
+
+				var updatedBatch = repository.find( batch.getId() );
+
+				expect( updatedBatch.getPendingJobs() ).toBe( 0 );
+				expect( updatedBatch.getFailedJobs() ).toBe( 0 );
+				expect( updatedBatch.getSuccessfulJobs() ).toBe( 1 );
+			} );
+
+			it( "retryable errors do not change pending, successful, or failed counts", function() {
+				var repository = getWireBox().getInstance( "DBBatchRepository@cbq" );
+				var config = registerSyncConnectionAndWorkerPool();
+				var batch = createTrackedBatch( repository, 1 );
+				var provider = config.getConnection( "syncBatchCounts" ).getProvider();
+				var pool = config.getWorkerPool( "syncBatchCounts" );
+
+				var job = getWireBox()
+					.getInstance( "@cbq" )
+					.job( "AlwaysErrorJob" )
+					.setId( createUUID() )
+					.withBatchId( batch.getId() )
+					.setCurrentAttempt( 1 )
+					.setMaxAttempts( 2 );
+
+				expect( () => provider.marshalJob( job, pool ) ).toThrow( "cbq.SyncProviderJobFailed" );
+
+				var updatedBatch = repository.find( batch.getId() );
+
+				expect( updatedBatch.getPendingJobs() ).toBe( 1 );
+				expect( updatedBatch.getSuccessfulJobs() ).toBe( 0 );
+				expect( updatedBatch.getFailedJobs() ).toBe( 0 );
+				expect( updatedBatch.getFailedJobIds() ).toBeEmpty();
+			} );
+
+			it( "failed jobs increment failedJobs, append failedJobIds, and decrement pendingJobs", function() {
+				var repository = getWireBox().getInstance( "DBBatchRepository@cbq" );
+				var config = registerSyncConnectionAndWorkerPool();
+				var batch = createTrackedBatch( repository, 1 );
+				var provider = config.getConnection( "syncBatchCounts" ).getProvider();
+				var pool = config.getWorkerPool( "syncBatchCounts" );
+				var failedJobId = createUUID();
+
+				var job = getWireBox()
+					.getInstance( "@cbq" )
+					.job( "AlwaysErrorJob" )
+					.setId( failedJobId )
+					.withBatchId( batch.getId() )
+					.setCurrentAttempt( 1 )
+					.setMaxAttempts( 1 );
+
+				expect( () => provider.marshalJob( job, pool ) ).toThrow();
+
+				var updatedBatch = repository.find( batch.getId() );
+
+				expect( updatedBatch.getPendingJobs() ).toBe( 0 );
+				expect( updatedBatch.getSuccessfulJobs() ).toBe( 0 );
+				expect( updatedBatch.getFailedJobs() ).toBe( 1 );
+				expect( updatedBatch.getFailedJobIds() ).toHaveLength( 1 );
+				expect( updatedBatch.getFailedJobIds()[ 1 ] ).toBe( failedJobId );
+			} );
+		} );
+	}
+
+	private any function registerSyncConnectionAndWorkerPool() {
+		var config = getWireBox().getInstance( "Config@cbq" );
+
+		if ( !config.getConnections().keyExists( "syncBatchCounts" ) ) {
+			config.registerConnection(
+				name = "syncBatchCounts",
+				provider = getWireBox().getInstance( "SyncProvider@cbq" ).setProperties( {} )
+			);
+		}
+
+		if ( !config.getWorkerPools().keyExists( "syncBatchCounts" ) ) {
+			config.registerWorkerPool(
+				name = "syncBatchCounts",
+				connectionName = "syncBatchCounts",
+				maxAttempts = 2
+			);
+		}
+
+		return config;
+	}
+
+	private any function createTrackedBatch( required any repository, required numeric totalJobs ) {
+		var pendingBatch = getWireBox()
+			.getInstance( "@cbq" )
+			.batch( [] )
+			.allowFailures();
+		var batch = arguments.repository.store( pendingBatch );
+		arguments.repository.incrementTotalJobs( batch.getId(), arguments.totalJobs );
+		return arguments.repository.find( batch.getId() );
+	}
+
+}

--- a/tests/specs/integration/Providers/DBProviderMaxAttemptsSpec.cfc
+++ b/tests/specs/integration/Providers/DBProviderMaxAttemptsSpec.cfc
@@ -138,10 +138,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				);
 			} );
 
-			it( "still marks the row failed when releaseJob throws inside the exception handler", function() {
+			it( "calls markJobFailed when releaseJob throws inside the exception handler", function() {
 				// Regression: previously, if releaseJob threw inside .onException, the
 				// future swallowed the secondary exception and the row stayed reserved,
-				// causing unbounded timeout-based re-pickups.
+				// causing unbounded timeout-based re-pickups. We verify markJobFailed is
+				// invoked (the action that terminates the retry loop), not the DB write itself,
+				// because WireBox provider methods (newQuery) are not reliably callable through
+				// MockBox pass-through in async threads.
 				var job = getWireBox()
 					.getInstance( "AlwaysErrorJob" )
 					.setMaxAttempts( 5 )
@@ -153,9 +156,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				job.setId( jobId );
 
 				prepareMock( variables.provider );
+				makePublic( variables.provider, "markJobFailed" );
 				variables.provider
 					.$( "releaseJob" )
 					.$throws( type = "TestSimulatedFailure", message = "simulated releaseJob failure" );
+				variables.provider.$( "markJobFailed" );
 
 				try {
 					var jobFuture = variables.provider.marshalJob( job, variables.pool );
@@ -165,14 +170,8 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				} catch ( any e ) {
 				}
 
-				var row = variables.provider
-					.newQuery()
-					.from( "cbq_jobs" )
-					.where( "id", jobId )
-					.first();
-				expect( row.failedDate ?: "" ).notToBe(
-					"",
-					"the row must be marked failed even when releaseJob throws, otherwise the timeout watcher will retry it forever"
+				expect( variables.provider.$atLeast( 1, "markJobFailed" ) ).toBeTrue(
+					"markJobFailed must be called when releaseJob throws so the row exits the retry loop"
 				);
 			} );
 

--- a/tests/specs/integration/Providers/DBProviderMaxAttemptsSpec.cfc
+++ b/tests/specs/integration/Providers/DBProviderMaxAttemptsSpec.cfc
@@ -144,9 +144,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				// causing unbounded timeout-based re-pickups.
 				// We use a real subclass (FailingReleaseDBProvider) instead of MockBox so that
 				// WireBox provider methods (newQuery) continue to work inside the async thread.
-				var failingProvider = getWireBox()
-					.getInstance( "FailingReleaseDBProvider" )
-					.setProperties( {} );
+				var failingProvider = getWireBox().getInstance( "FailingReleaseDBProvider" ).setProperties( {} );
 				var failingPool = makeWorkerPool( failingProvider );
 
 				failingProvider
@@ -166,9 +164,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					.newQuery()
 					.table( "cbq_jobs" )
 					.update( {
-						"reservedBy"   : failingPool.getUniqueId(),
+						"reservedBy" : failingPool.getUniqueId(),
 						"reservedDate" : now,
-						"availableDate": now + 60
+						"availableDate" : now + 60
 					} );
 
 				var jobId = failingProvider

--- a/tests/specs/integration/Providers/DBProviderMaxAttemptsSpec.cfc
+++ b/tests/specs/integration/Providers/DBProviderMaxAttemptsSpec.cfc
@@ -1,0 +1,243 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function run() {
+		describe( "DBProvider maxAttempts safeguards", function() {
+			beforeEach( function() {
+				variables.provider = getWireBox().getInstance( "DBProvider@cbq" ).setProperties( {} );
+				makePublic( variables.provider, "processLockedRecord" );
+				variables.pool = makeWorkerPool( variables.provider );
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.delete();
+			} );
+
+			afterEach( function() {
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.delete();
+			} );
+
+			it( "forceFailJob sets failedDate and clears the reservation", function() {
+				var job = getWireBox().getInstance( "SendWelcomeEmailJob" ).setMaxAttempts( 3 );
+				variables.provider.push( "default", job );
+
+				var now = javacast( "long", getTickCount() / 1000 );
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.update( {
+						"reservedBy" : variables.pool.getUniqueId(),
+						"reservedDate" : now,
+						"availableDate" : now + 60,
+						"attempts" : 5
+					} );
+
+				var jobId = variables.provider
+					.newQuery()
+					.from( "cbq_jobs" )
+					.value( "id" );
+
+				variables.provider.forceFailJob( jobId, variables.pool );
+
+				var row = variables.provider
+					.newQuery()
+					.from( "cbq_jobs" )
+					.where( "id", jobId )
+					.first();
+
+				expect( row.failedDate ).notToBeNull( "failedDate should be set" );
+				expect( row.failedDate ).toBeGT( 0, "failedDate should be a unix timestamp" );
+				expect( row.reservedBy ?: "" ).toBe( "", "reservedBy should be cleared" );
+				expect( row.reservedDate ?: "" ).toBe( "", "reservedDate should be cleared" );
+			} );
+
+			it( "skips dispatch and marks the job failed when attempts already meets maxAttempts", function() {
+				var job = getWireBox().getInstance( "AlwaysErrorJob" ).setMaxAttempts( 3 );
+				variables.provider.push( "default", job );
+
+				var now = javacast( "long", getTickCount() / 1000 );
+				// Simulate the runaway state: 29 attempts in DB, payload still says maxAttempts=3,
+				// reserved by this pool but reservedDate was never set (the symptom we observed).
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.update( {
+						"reservedBy" : variables.pool.getUniqueId(),
+						"reservedDate" : {
+							"value" : "",
+							"null" : true,
+							"nulls" : true
+						},
+						"availableDate" : now - 1,
+						"attempts" : 29
+					} );
+
+				var record = variables.provider
+					.newQuery()
+					.from( "cbq_jobs" )
+					.first();
+
+				prepareMock( variables.provider );
+				variables.provider.$( "incrementJobAttempts" );
+				variables.provider.$( "marshalJob" );
+
+				variables.provider.processLockedRecord( record, variables.pool );
+
+				expect( variables.provider.$never( "incrementJobAttempts" ) ).toBeTrue(
+					"incrementJobAttempts must not run once attempts >= maxAttempts"
+				);
+				expect( variables.provider.$never( "marshalJob" ) ).toBeTrue(
+					"marshalJob must not run once attempts >= maxAttempts"
+				);
+
+				var row = variables.provider
+					.newQuery()
+					.from( "cbq_jobs" )
+					.where( "id", record.id )
+					.first();
+				expect( row.failedDate ).notToBeNull( "the runaway job should be marked failed" );
+			} );
+
+			it( "still proceeds normally when attempts is below maxAttempts", function() {
+				var job = getWireBox().getInstance( "SendWelcomeEmailJob" ).setMaxAttempts( 3 );
+				variables.provider.push( "default", job );
+
+				var now = javacast( "long", getTickCount() / 1000 );
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.update( {
+						"reservedBy" : variables.pool.getUniqueId(),
+						"reservedDate" : {
+							"value" : "",
+							"null" : true,
+							"nulls" : true
+						},
+						"availableDate" : now - 1,
+						"attempts" : 1
+					} );
+
+				var record = variables.provider
+					.newQuery()
+					.from( "cbq_jobs" )
+					.first();
+
+				prepareMock( variables.provider );
+				variables.provider.$( "incrementJobAttempts" );
+				variables.provider.$( "marshalJob" );
+
+				variables.provider.processLockedRecord( record, variables.pool );
+
+				expect( variables.provider.$once( "incrementJobAttempts" ) ).toBeTrue(
+					"incrementJobAttempts should run when attempts < maxAttempts"
+				);
+				expect( variables.provider.$once( "marshalJob" ) ).toBeTrue(
+					"marshalJob should run when attempts < maxAttempts"
+				);
+			} );
+
+			it( "still marks the row failed when releaseJob throws inside the exception handler", function() {
+				// Regression: previously, if releaseJob threw inside .onException, the
+				// future swallowed the secondary exception and the row stayed reserved,
+				// causing unbounded timeout-based re-pickups.
+				var job = getWireBox()
+					.getInstance( "AlwaysErrorJob" )
+					.setMaxAttempts( 5 )
+					.setCurrentAttempt( 0 )
+					.setId( randRange( 1, 1000 ) );
+
+				variables.provider.push( "default", job );
+				var jobId = reserveJobForPool();
+				job.setId( jobId );
+
+				prepareMock( variables.provider );
+				variables.provider
+					.$( "releaseJob" )
+					.$throws( type = "TestSimulatedFailure", message = "simulated releaseJob failure" );
+
+				try {
+					var jobFuture = variables.provider.marshalJob( job, variables.pool );
+					if ( !isNull( jobFuture ) ) {
+						jobFuture.get();
+					}
+				} catch ( any e ) {
+				}
+
+				var row = variables.provider
+					.newQuery()
+					.from( "cbq_jobs" )
+					.where( "id", jobId )
+					.first();
+				expect( row.failedDate ?: "" ).notToBe(
+					"",
+					"the row must be marked failed even when releaseJob throws, otherwise the timeout watcher will retry it forever"
+				);
+			} );
+
+			it( "falls back to forceFailJob when even afterJobFailed throws", function() {
+				// Floor of the defense: if the proper failure-recording path is broken,
+				// markJobFailed should escalate to forceFailJob to guarantee the row exits
+				// the retry loop.
+				var job = getWireBox()
+					.getInstance( "AlwaysErrorJob" )
+					.setMaxAttempts( 1 )
+					.setCurrentAttempt( 0 )
+					.setId( randRange( 1, 1000 ) );
+
+				variables.provider.push( "default", job );
+				var jobId = reserveJobForPool();
+				job.setId( jobId );
+
+				prepareMock( variables.provider );
+				makePublic( variables.provider, "afterJobFailed" );
+				variables.provider
+					.$( "afterJobFailed" )
+					.$throws( type = "TestSimulatedFailure", message = "simulated afterJobFailed failure" );
+				variables.provider.$( "forceFailJob" );
+
+				try {
+					var jobFuture = variables.provider.marshalJob( job, variables.pool );
+					if ( !isNull( jobFuture ) ) {
+						jobFuture.get();
+					}
+				} catch ( any e ) {
+				}
+
+				expect( variables.provider.$atLeast( 1, "forceFailJob" ) ).toBeTrue(
+					"forceFailJob must run when afterJobFailed throws"
+				);
+			} );
+		} );
+	}
+
+	private numeric function reserveJobForPool() {
+		var now = javacast( "long", getTickCount() / 1000 );
+		variables.provider
+			.newQuery()
+			.table( "cbq_jobs" )
+			.update( {
+				"reservedBy" : variables.pool.getUniqueId(),
+				"reservedDate" : now,
+				"availableDate" : now + 60
+			} );
+		return variables.provider
+			.newQuery()
+			.from( "cbq_jobs" )
+			.value( "id" );
+	}
+
+	private any function makeWorkerPool( required any provider ) {
+		var connection = getInstance( "QueueConnection@cbq" )
+			.setName( "TestMaxAttemptsConnection" )
+			.setProvider( arguments.provider );
+
+		return getInstance( "WorkerPool@cbq" )
+			.setName( "TestMaxAttemptsPool" )
+			.setConnection( connection )
+			.setConnectionName( connection.getName() )
+			.startWorkers();
+	}
+
+}

--- a/tests/specs/integration/Providers/DBProviderMaxAttemptsSpec.cfc
+++ b/tests/specs/integration/Providers/DBProviderMaxAttemptsSpec.cfc
@@ -138,41 +138,69 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				);
 			} );
 
-			it( "calls markJobFailed when releaseJob throws inside the exception handler", function() {
+			it( "still marks the row failed when releaseJob throws inside the exception handler", function() {
 				// Regression: previously, if releaseJob threw inside .onException, the
 				// future swallowed the secondary exception and the row stayed reserved,
-				// causing unbounded timeout-based re-pickups. We verify markJobFailed is
-				// invoked (the action that terminates the retry loop), not the DB write itself,
-				// because WireBox provider methods (newQuery) are not reliably callable through
-				// MockBox pass-through in async threads.
+				// causing unbounded timeout-based re-pickups.
+				// We use a real subclass (FailingReleaseDBProvider) instead of MockBox so that
+				// WireBox provider methods (newQuery) continue to work inside the async thread.
+				var failingProvider = getWireBox()
+					.getInstance( "FailingReleaseDBProvider" )
+					.setProperties( {} );
+				var failingPool = makeWorkerPool( failingProvider );
+
+				failingProvider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.delete();
+
 				var job = getWireBox()
 					.getInstance( "AlwaysErrorJob" )
 					.setMaxAttempts( 5 )
-					.setCurrentAttempt( 0 )
-					.setId( randRange( 1, 1000 ) );
+					.setCurrentAttempt( 0 );
 
-				variables.provider.push( "default", job );
-				var jobId = reserveJobForPool();
+				failingProvider.push( "default", job );
+
+				var now = javacast( "long", getTickCount() / 1000 );
+				failingProvider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.update( {
+						"reservedBy"   : failingPool.getUniqueId(),
+						"reservedDate" : now,
+						"availableDate": now + 60
+					} );
+
+				var jobId = failingProvider
+					.newQuery()
+					.from( "cbq_jobs" )
+					.value( "id" );
+
 				job.setId( jobId );
 
-				prepareMock( variables.provider );
-				makePublic( variables.provider, "markJobFailed" );
-				variables.provider
-					.$( "releaseJob" )
-					.$throws( type = "TestSimulatedFailure", message = "simulated releaseJob failure" );
-				variables.provider.$( "markJobFailed" );
-
 				try {
-					var jobFuture = variables.provider.marshalJob( job, variables.pool );
+					var jobFuture = failingProvider.marshalJob( job, failingPool );
 					if ( !isNull( jobFuture ) ) {
 						jobFuture.get();
 					}
 				} catch ( any e ) {
 				}
 
-				expect( variables.provider.$atLeast( 1, "markJobFailed" ) ).toBeTrue(
-					"markJobFailed must be called when releaseJob throws so the row exits the retry loop"
+				var row = failingProvider
+					.newQuery()
+					.from( "cbq_jobs" )
+					.where( "id", jobId )
+					.first();
+
+				expect( row.failedDate ?: "" ).notToBe(
+					"",
+					"the row must be marked failed even when releaseJob throws, otherwise the timeout watcher will retry it forever"
 				);
+
+				failingProvider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.delete();
 			} );
 
 			it( "falls back to forceFailJob when even afterJobFailed throws", function() {

--- a/tests/specs/integration/Providers/DBProviderTimeoutWatcherSpec.cfc
+++ b/tests/specs/integration/Providers/DBProviderTimeoutWatcherSpec.cfc
@@ -1,0 +1,107 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function run() {
+		describe( "DBProvider timeout watcher", function() {
+			beforeEach( function() {
+				variables.provider = getWireBox().getInstance( "DBProvider@cbq" ).setProperties( {} );
+				makePublic( variables.provider, "fetchPotentiallyOpenRecords" );
+				variables.pool = makeWorkerPool( variables.provider );
+				// clean up any leftover test records
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.delete();
+			} );
+
+			afterEach( function() {
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.delete();
+			} );
+
+			it( "does not re-grab a reserved job that is still within its job-specific timeout", function() {
+				var job = getWireBox().getInstance( "SendWelcomeEmailJob" );
+				variables.provider.push( "default", job );
+
+				// Simulate the job being reserved by another worker with a 300s job timeout
+				var otherWorkerUUID = createUUID();
+				var now = javacast( "long", getTickCount() / 1000 );
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.update( {
+						"reservedBy" : otherWorkerUUID,
+						"reservedDate" : now,
+						"availableDate" : now + 300
+					} );
+
+				var ids = variables.provider.fetchPotentiallyOpenRecords( capacity = 10, pool = variables.pool );
+
+				expect( ids ).toBeEmpty( "A reserved job still within its job-specific timeout should not be re-grabbed" );
+			} );
+
+			it( "re-grabs a reserved job whose job-specific timeout has expired", function() {
+				var job = getWireBox().getInstance( "SendWelcomeEmailJob" );
+				variables.provider.push( "default", job );
+
+				// Simulate the job being reserved 310s ago with a 300s job timeout (availableDate now in the past)
+				var otherWorkerUUID = createUUID();
+				var now = javacast( "long", getTickCount() / 1000 );
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.update( {
+						"reservedBy" : otherWorkerUUID,
+						"reservedDate" : now - 310,
+						"availableDate" : now - 10
+					} );
+
+				var ids = variables.provider.fetchPotentiallyOpenRecords( capacity = 10, pool = variables.pool );
+
+				expect( ids ).toHaveLength(
+					1,
+					"A reserved job whose job-specific timeout has expired should be re-grabbed"
+				);
+			} );
+
+			it( "does not re-grab a job using the pool timeout when the job-specific timeout is longer", function() {
+				// Core bug fix: pool timeout is 60s, job timeout is 300s.
+				// After 65s (past pool timeout, within job timeout), job should NOT be re-grabbed.
+				var job = getWireBox().getInstance( "SendWelcomeEmailJob" );
+				variables.provider.push( "default", job );
+
+				var otherWorkerUUID = createUUID();
+				var now = javacast( "long", getTickCount() / 1000 );
+				// Reserved 65s ago, job timeout is 300s, so availableDate is still 235s in the future
+				variables.provider
+					.newQuery()
+					.table( "cbq_jobs" )
+					.update( {
+						"reservedBy" : otherWorkerUUID,
+						"reservedDate" : now - 65,
+						"availableDate" : now + 235
+					} );
+
+				var ids = variables.provider.fetchPotentiallyOpenRecords( capacity = 10, pool = variables.pool );
+
+				expect( ids ).toBeEmpty(
+					"A job past the pool timeout but still within its job-specific timeout should not be re-grabbed"
+				);
+			} );
+		} );
+	}
+
+	private any function makeWorkerPool( required any provider ) {
+		var connection = getInstance( "QueueConnection@cbq" )
+			.setName( "TestTimeoutWatcherConnection" )
+			.setProvider( arguments.provider );
+
+		return getInstance( "WorkerPool@cbq" )
+			.setName( "TestTimeoutWatcherPool" )
+			.setConnection( connection )
+			.setConnectionName( connection.getName() )
+			.startWorkers();
+	}
+
+}

--- a/tests/specs/integration/Providers/SyncProviderOnFailureSpec.cfc
+++ b/tests/specs/integration/Providers/SyncProviderOnFailureSpec.cfc
@@ -1,0 +1,45 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function run() {
+		describe( "SyncProvider onFailure exception argument", function() {
+			beforeEach( function() {
+				structDelete( application, "onFailureExceptionReceived" );
+				structDelete( application, "onFailureExceptionIsExpcetion" );
+			} );
+
+			it( "passes the exception as 'exception' (not 'excpetion') to the onFailure handler", function() {
+				var provider = getWireBox().getInstance( "SyncProvider@cbq" ).setProperties( {} );
+				var pool = makeWorkerPool( provider );
+				var job = getInstance( "OnFailureCapturingJob" )
+					.setId( createUUID() )
+					.setCurrentAttempt( 1 )
+					.setMaxAttempts( 1 );
+
+				param application.onFailureExceptionReceived = false;
+				param application.onFailureExceptionIsExpcetion = true;
+
+				expect( () => provider.marshalJob( job, pool ) ).toThrow();
+
+				expect( application.onFailureExceptionReceived ).toBeTrue(
+					"onFailure should receive the exception under the key 'exception'"
+				);
+				expect( application.onFailureExceptionIsExpcetion ).toBeFalse(
+					"onFailure should NOT receive the exception under the misspelled key 'excpetion'"
+				);
+			} );
+		} );
+	}
+
+	private any function makeWorkerPool( required any provider ) {
+		var connection = getInstance( "QueueConnection@cbq" )
+			.setName( "TestOnFailureConnection" )
+			.setProvider( arguments.provider );
+
+		return getInstance( "WorkerPool@cbq" )
+			.setName( "TestOnFailurePool" )
+			.setConnection( connection )
+			.setConnectionName( connection.getName() )
+			.startWorkers();
+	}
+
+}

--- a/tests/specs/integration/Providers/SyncProviderOnFailureSpec.cfc
+++ b/tests/specs/integration/Providers/SyncProviderOnFailureSpec.cfc
@@ -4,7 +4,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 		describe( "SyncProvider onFailure exception argument", function() {
 			beforeEach( function() {
 				structDelete( application, "onFailureExceptionReceived" );
-				structDelete( application, "onFailureExceptionIsExpcetion" );
+				structDelete( application, "onFailureExceptionHasExcpetionKey" );
 			} );
 
 			it( "passes the exception as 'exception' (not 'excpetion') to the onFailure handler", function() {
@@ -16,14 +16,14 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					.setMaxAttempts( 1 );
 
 				param application.onFailureExceptionReceived = false;
-				param application.onFailureExceptionIsExpcetion = true;
+				param application.onFailureExceptionHasExcpetionKey = true;
 
 				expect( () => provider.marshalJob( job, pool ) ).toThrow();
 
 				expect( application.onFailureExceptionReceived ).toBeTrue(
 					"onFailure should receive the exception under the key 'exception'"
 				);
-				expect( application.onFailureExceptionIsExpcetion ).toBeFalse(
+				expect( application.onFailureExceptionHasExcpetionKey ).toBeFalse(
 					"onFailure should NOT receive the exception under the misspelled key 'excpetion'"
 				);
 			} );


### PR DESCRIPTION
## Summary

- **Runaway retry guard in the pickup loop** — `processLockedRecord` now checks `attempts >= maxAttempts` *before* incrementing or dispatching. Jobs stuck in the runaway state (reserved but never executed, attempts already at the cap) are immediately marked failed instead of being dispatched again.
- **Hardened `marshalJob` exception handler** — if `releaseJob` throws inside `.onException`, the handler now falls back to `markJobFailed` (terminal) instead of letting the future swallow the secondary exception and leaving the row reserved. If `afterJobFailed` itself throws, `forceFailJob` is called as a last resort to guarantee the row exits the retry loop.
- **`forceFailJob` on DBProvider** — minimal, bulletproof write that sets `failedDate` and clears `reservedBy`/`reservedDate` unconditionally, bypassing all bookkeeping. Used only when normal failure paths are broken.
- **Integration test suite** — new `DBProviderMaxAttemptsSpec` covers: `forceFailJob` behaviour, runaway-job pre-flight guard, normal-path pass-through, `releaseJob`-throws fallback, and `afterJobFailed`-throws escalation.